### PR TITLE
feat: add allocation efficiency panels, recording rules, and alert

### DIFF
--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -157,6 +157,36 @@
           },
         ],
       },
+      if $._config.alerts.efficiency.enabled then {
+        name: 'opencost-efficiency',
+        rules: [
+          {
+            // Fires when a namespace's cost-weighted efficiency stays below the
+            // configured threshold over 7d AND the namespace is spending more
+            // than minMonthlyCostThreshold. Mirrors OpenCost's native formula
+            // (see core/pkg/opencost/allocation.go — CPUEfficiency, RAMEfficiency,
+            // TotalEfficiency). Spec: https://www.opencost.io/docs/specification#efficiency
+            alert: 'OpenCostLowEfficiencyNamespace',
+            expr: |||
+              avg_over_time(namespace:efficiency_total:ratio[7d]) < %(minEfficiencyThreshold)s
+              and
+              (
+                avg_over_time(namespace:opencost_cpu_cost:sum[7d])
+                + avg_over_time(namespace:opencost_ram_cost:sum[7d])
+              ) * 730 > %(minMonthlyCostThreshold)s
+            ||| % $._config.alerts.efficiency,
+            labels: {
+              severity: $._config.alerts.efficiency.severity,
+            },
+            'for': '1h',
+            annotations: {
+              summary: 'Namespace {{ $labels.namespace }} on {{ $labels.%(clusterLabel)s }} is chronically under-utilizing its requests' % $._config,
+              description: ('Total CPU+RAM cost-weighted efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.%(clusterLabel)s }} has averaged {{ $value | humanizePercentage }} over the last 7 days while projected monthly cost exceeds $%(minMonthlyCostThreshold)s. Consider rightsizing container requests. Formula mirrors OpenCost allocation.go (CPUEfficiency, RAMEfficiency, TotalEfficiency) — spec at https://www.opencost.io/docs/specification#efficiency.') % ($._config { minMonthlyCostThreshold: $._config.alerts.efficiency.minMonthlyCostThreshold }),
+              dashboard_url: $._config.dashboardUrls['opencost-namespace'] + clusterVariableQueryString,
+            },
+          },
+        ],
+      },
     ]),
   },
 }

--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -162,20 +162,30 @@
         rules: [
           {
             // Fires when a namespace's cost-weighted allocation efficiency stays
-            // below the configured threshold over 7d. This uses OpenCost-exported
-            // allocation metrics as the denominator; OpenCost UI/API efficiency
-            // uses request-average denominators.
+            // below the configured threshold over 7d, ignoring low-cost namespaces.
+            // This uses OpenCost-exported allocation metrics as the denominator;
+            // OpenCost UI/API efficiency uses request-average denominators.
             alert: 'OpenCostLowEfficiencyNamespace',
             expr: |||
-              avg_over_time(namespace:efficiency_total:ratio[7d]) < %(minEfficiencyThreshold)s
-            ||| % $._config.alerts.efficiency,
+              (
+                avg_over_time(namespace:efficiency_total:ratio[7d]) < %(minEfficiencyThreshold)s
+              )
+              and on(%(clusterLabel)s, namespace)
+              (
+                (
+                  avg_over_time(namespace:opencost_cpu_cost:sum[7d])
+                  +
+                  avg_over_time(namespace:opencost_ram_cost:sum[7d])
+                ) * 730 > %(minMonthlyCostThreshold)s
+              )
+            ||| % ($._config.alerts.efficiency { clusterLabel: $._config.clusterLabel }),
             labels: {
               severity: $._config.alerts.efficiency.severity,
             },
             'for': '1h',
             annotations: {
               summary: 'Namespace {{ $labels.namespace }} on {{ $labels.%(clusterLabel)s }} is chronically under-utilizing its requests' % $._config,
-              description: 'Total CPU+RAM cost-weighted allocation efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.%(clusterLabel)s }} has averaged {{ $value | humanizePercentage }} over the last 7 days. This is usage divided by OpenCost-exported allocation, not exact OpenCost UI/API request-based efficiency. Consider rightsizing container requests.' % $._config,
+              description: 'Total CPU+RAM cost-weighted allocation efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.%(clusterLabel)s }} has averaged {{ $value | humanizePercentage }} over the last 7 days, with projected monthly CPU+RAM cost above $%(minMonthlyCostThreshold)s. This is usage divided by OpenCost-exported allocation, not exact OpenCost UI/API request-based efficiency. Consider rightsizing container requests.' % ($._config { minMonthlyCostThreshold: $._config.alerts.efficiency.minMonthlyCostThreshold }),
               dashboard_url: $._config.dashboardUrls['opencost-namespace'] + clusterVariableQueryString,
             },
           },

--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -162,18 +162,12 @@
         rules: [
           {
             // Fires when a namespace's cost-weighted efficiency stays below the
-            // configured threshold over 7d AND the namespace is spending more
-            // than minMonthlyCostThreshold. Mirrors OpenCost's native formula
+            // configured threshold over 7d. Mirrors OpenCost's native formula
             // (see core/pkg/opencost/allocation.go — CPUEfficiency, RAMEfficiency,
             // TotalEfficiency). Spec: https://www.opencost.io/docs/specification#efficiency
             alert: 'OpenCostLowEfficiencyNamespace',
             expr: |||
               avg_over_time(namespace:efficiency_total:ratio[7d]) < %(minEfficiencyThreshold)s
-              and
-              (
-                avg_over_time(namespace:opencost_cpu_cost:sum[7d])
-                + avg_over_time(namespace:opencost_ram_cost:sum[7d])
-              ) * 730 > %(minMonthlyCostThreshold)s
             ||| % $._config.alerts.efficiency,
             labels: {
               severity: $._config.alerts.efficiency.severity,
@@ -181,7 +175,7 @@
             'for': '1h',
             annotations: {
               summary: 'Namespace {{ $labels.namespace }} on {{ $labels.%(clusterLabel)s }} is chronically under-utilizing its requests' % $._config,
-              description: ('Total CPU+RAM cost-weighted efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.%(clusterLabel)s }} has averaged {{ $value | humanizePercentage }} over the last 7 days while projected monthly cost exceeds $%(minMonthlyCostThreshold)s. Consider rightsizing container requests. Formula mirrors OpenCost allocation.go (CPUEfficiency, RAMEfficiency, TotalEfficiency) — spec at https://www.opencost.io/docs/specification#efficiency.') % ($._config { minMonthlyCostThreshold: $._config.alerts.efficiency.minMonthlyCostThreshold }),
+              description: 'Total CPU+RAM cost-weighted efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.%(clusterLabel)s }} has averaged {{ $value | humanizePercentage }} over the last 7 days. Consider rightsizing container requests. Formula mirrors OpenCost allocation.go (CPUEfficiency, RAMEfficiency, TotalEfficiency) — spec at https://www.opencost.io/docs/specification#efficiency.' % $._config,
               dashboard_url: $._config.dashboardUrls['opencost-namespace'] + clusterVariableQueryString,
             },
           },

--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -161,10 +161,10 @@
         name: 'opencost-efficiency',
         rules: [
           {
-            // Fires when a namespace's cost-weighted efficiency stays below the
-            // configured threshold over 7d. Mirrors OpenCost's native formula
-            // (see core/pkg/opencost/allocation.go — CPUEfficiency, RAMEfficiency,
-            // TotalEfficiency). Spec: https://www.opencost.io/docs/specification#efficiency
+            // Fires when a namespace's cost-weighted allocation efficiency stays
+            // below the configured threshold over 7d. This uses OpenCost-exported
+            // allocation metrics as the denominator; OpenCost UI/API efficiency
+            // uses request-average denominators.
             alert: 'OpenCostLowEfficiencyNamespace',
             expr: |||
               avg_over_time(namespace:efficiency_total:ratio[7d]) < %(minEfficiencyThreshold)s
@@ -175,7 +175,7 @@
             'for': '1h',
             annotations: {
               summary: 'Namespace {{ $labels.namespace }} on {{ $labels.%(clusterLabel)s }} is chronically under-utilizing its requests' % $._config,
-              description: 'Total CPU+RAM cost-weighted efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.%(clusterLabel)s }} has averaged {{ $value | humanizePercentage }} over the last 7 days. Consider rightsizing container requests. Formula mirrors OpenCost allocation.go (CPUEfficiency, RAMEfficiency, TotalEfficiency) — spec at https://www.opencost.io/docs/specification#efficiency.' % $._config,
+              description: 'Total CPU+RAM cost-weighted allocation efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.%(clusterLabel)s }} has averaged {{ $value | humanizePercentage }} over the last 7 days. This is usage divided by OpenCost-exported allocation, not exact OpenCost UI/API request-based efficiency. Consider rightsizing container requests.' % $._config,
               dashboard_url: $._config.dashboardUrls['opencost-namespace'] + clusterVariableQueryString,
             },
           },

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -45,6 +45,14 @@ local annotation = g.dashboard.annotation;
         enabled: true,
         anomalyPercentageThreshold: 15,
       },
+      efficiency: {
+        enabled: true,
+        // Fire when namespace total (cost-weighted) efficiency falls below this ratio.
+        minEfficiencyThreshold: 0.20,
+        // Only evaluate namespaces whose projected monthly cost exceeds this USD amount.
+        minMonthlyCostThreshold: 500,
+        severity: 'info',
+      },
     },
 
     tags: ['opencost', 'opencost-mixin'],

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -12,6 +12,12 @@ local annotation = g.dashboard.annotation;
 
     openCostSelector: 'job="opencost"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
+    // Label selector for cAdvisor / kubelet metrics used in the efficiency
+    // recording rules (container_cpu_usage_seconds_total,
+    // container_memory_working_set_bytes). Override to match your scrape
+    // config — common alternatives are 'job="kubelet", metrics_path="/metrics/cadvisor"'
+    // (kube-prometheus-stack) or 'job="cadvisor"'.
+    cadvisorSelector: 'job="kube-system/cadvisor"',
 
     // Default datasource name
     datasourceName: 'default',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -55,8 +55,6 @@ local annotation = g.dashboard.annotation;
         enabled: true,
         // Fire when namespace total (cost-weighted) efficiency falls below this ratio.
         minEfficiencyThreshold: 0.20,
-        // Only evaluate namespaces whose projected monthly cost exceeds this USD amount.
-        minMonthlyCostThreshold: 500,
         severity: 'info',
       },
     },

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -55,6 +55,8 @@ local annotation = g.dashboard.annotation;
         enabled: true,
         // Fire when namespace total (cost-weighted) efficiency falls below this ratio.
         minEfficiencyThreshold: 0.20,
+        // Ignore low-efficiency namespaces below this projected monthly CPU+RAM cost.
+        minMonthlyCostThreshold: 100,
         severity: 'info',
       },
     },

--- a/dashboards/opencost-namespace.libsonnet
+++ b/dashboards/opencost-namespace.libsonnet
@@ -303,6 +303,38 @@ local tbOverride = tbStandardOptions.override;
         ||| % defaultFilters,
         pvMonthlyCostByPv: std.strReplace(queries.monthlyPVCost, '* 730', 'by (persistentvolume) * 730'),
         pvcMonthlyCostByClaim: std.strReplace(queries.monthlyPVCost, '* 730', 'by (persistentvolumeclaim) * 730'),
+
+        // Efficiency queries — mirror OpenCost's native CPUEfficiency, RAMEfficiency and
+        // TotalEfficiency calculation (see https://www.opencost.io/docs/specification#efficiency).
+        // Backed by the opencost.rules.efficiency recording rules shipped in this mixin.
+        // The recording rules aggregate by (cluster, namespace) so the job label is not
+        // present; queries below select by cluster+namespace only.
+        namespaceCpuEfficiency: 'namespace:efficiency_cpu:ratio{%(cluster)s, %(namespace)s}' % defaultFilters,
+        namespaceRamEfficiency: 'namespace:efficiency_ram:ratio{%(cluster)s, %(namespace)s}' % defaultFilters,
+        namespaceTotalEfficiency: 'namespace:efficiency_total:ratio{%(cluster)s, %(namespace)s}' % defaultFilters,
+
+        namespaceMonthlyWaste: |||
+          (1 - namespace:efficiency_total:ratio{%(cluster)s, %(namespace)s})
+          *
+          (
+            namespace:opencost_cpu_cost:sum{%(cluster)s, %(namespace)s}
+            +
+            namespace:opencost_ram_cost:sum{%(cluster)s, %(namespace)s}
+          )
+          * 730
+        ||| % defaultFilters,
+
+        workloadCpuEfficiencyTopN: |||
+          topk(10,
+            workload:efficiency_cpu:ratio{%(cluster)s, %(namespace)s}
+          )
+        ||| % defaultFilters,
+
+        workloadRamEfficiencyTopN: |||
+          topk(10,
+            workload:efficiency_ram:ratio{%(cluster)s, %(namespace)s}
+          )
+        ||| % defaultFilters,
       };
 
       local panels = {
@@ -677,6 +709,74 @@ local tbOverride = tbStandardOptions.override;
             values=['percent', 'value'],
             description='Distribution of monthly storage costs across Persistent Volume Claims in the namespace. This shows which claims consume the most storage budget and helps identify whether storage costs are concentrated in a few large claims or distributed across many smaller ones.',
           ),
+
+        cpuEfficiencyStat:
+          dashboards.statPanel(
+            'CPU Efficiency',
+            'percentunit',
+            queries.namespaceCpuEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='CPU usage / CPU allocation for the selected namespace. Values well below 1.0 indicate containers that have been allocated more CPU than they are actually using. Mirrors the CPUEfficiency metric from the OpenCost UI.',
+          ),
+
+        ramEfficiencyStat:
+          dashboards.statPanel(
+            'RAM Efficiency',
+            'percentunit',
+            queries.namespaceRamEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='Working-set RAM / RAM allocation for the selected namespace. Mirrors the RAMEfficiency metric from the OpenCost UI.',
+          ),
+
+        totalEfficiencyStat:
+          dashboards.statPanel(
+            'Total Efficiency',
+            'percentunit',
+            queries.namespaceTotalEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='Namespace total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.',
+          ),
+
+        monthlyWasteStat:
+          dashboards.statPanel(
+            'Monthly Waste',
+            'currencyUSD',
+            queries.namespaceMonthlyWaste,
+            graphMode='none',
+            decimals=2,
+            description='Projected monthly spend in this namespace that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h.',
+          ),
+
+        workloadCpuEfficiencyTimeSeries:
+          dashboards.timeSeriesPanel(
+            'CPU Efficiency by Workload (Top 10)',
+            'percentunit',
+            [
+              {
+                expr: queries.workloadCpuEfficiencyTopN,
+                legend: '{{workload_type}}/{{workload}}',
+                interval: $._config.dashboardMinInterval,
+              },
+            ],
+            description='Top 10 workloads inside the selected namespace by CPU efficiency. Low values indicate workloads that have been allocated more CPU than they are actually using.',
+          ),
+
+        workloadRamEfficiencyTimeSeries:
+          dashboards.timeSeriesPanel(
+            'RAM Efficiency by Workload (Top 10)',
+            'percentunit',
+            [
+              {
+                expr: queries.workloadRamEfficiencyTopN,
+                legend: '{{workload_type}}/{{workload}}',
+                interval: $._config.dashboardMinInterval,
+              },
+            ],
+            description='Top 10 workloads inside the selected namespace by RAM efficiency.',
+          ),
       };
 
       local rows =
@@ -724,15 +824,44 @@ local tbOverride = tbStandardOptions.override;
         ) +
         [
           row.new(
-            'Pod Summary',
+            'Efficiency',
           ) +
           row.gridPos.withX(0) +
           row.gridPos.withY(23) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1),
+        ] +
+        grid.wrapPanels(
+          [
+            panels.cpuEfficiencyStat,
+            panels.ramEfficiencyStat,
+            panels.totalEfficiencyStat,
+            panels.monthlyWasteStat,
+          ],
+          panelWidth=6,
+          panelHeight=3,
+          startY=24
+        ) +
+        grid.wrapPanels(
+          [
+            panels.workloadCpuEfficiencyTimeSeries,
+            panels.workloadRamEfficiencyTimeSeries,
+          ],
+          panelWidth=12,
+          panelHeight=5,
+          startY=27
+        ) +
+        [
+          row.new(
+            'Pod Summary',
+          ) +
+          row.gridPos.withX(0) +
+          row.gridPos.withY(32) +
+          row.gridPos.withW(24) +
+          row.gridPos.withH(1),
           panels.podTable +
           tablePanel.gridPos.withX(0) +
-          tablePanel.gridPos.withY(24) +
+          tablePanel.gridPos.withY(33) +
           tablePanel.gridPos.withW(24) +
           tablePanel.gridPos.withH(10),
         ] +
@@ -741,12 +870,12 @@ local tbOverride = tbStandardOptions.override;
             'Container Summary',
           ) +
           row.gridPos.withX(0) +
-          row.gridPos.withY(34) +
+          row.gridPos.withY(43) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1),
           panels.containerTable +
           tablePanel.gridPos.withX(0) +
-          tablePanel.gridPos.withY(35) +
+          tablePanel.gridPos.withY(44) +
           tablePanel.gridPos.withW(24) +
           tablePanel.gridPos.withH(10),
         ] +
@@ -755,12 +884,12 @@ local tbOverride = tbStandardOptions.override;
             'PV Summary',
           ) +
           row.gridPos.withX(0) +
-          row.gridPos.withY(45) +
+          row.gridPos.withY(54) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1),
           panels.pvTable +
           tablePanel.gridPos.withX(0) +
-          tablePanel.gridPos.withY(46) +
+          tablePanel.gridPos.withY(55) +
           tablePanel.gridPos.withW(24) +
           tablePanel.gridPos.withH(10),
         ];

--- a/dashboards/opencost-namespace.libsonnet
+++ b/dashboards/opencost-namespace.libsonnet
@@ -313,17 +313,6 @@ local tbOverride = tbStandardOptions.override;
         namespaceRamEfficiency: 'namespace:efficiency_ram:ratio{%(cluster)s, %(namespace)s}' % defaultFilters,
         namespaceTotalEfficiency: 'namespace:efficiency_total:ratio{%(cluster)s, %(namespace)s}' % defaultFilters,
 
-        namespaceMonthlyWaste: |||
-          (1 - namespace:efficiency_total:ratio{%(cluster)s, %(namespace)s})
-          *
-          (
-            namespace:opencost_cpu_cost:sum{%(cluster)s, %(namespace)s}
-            +
-            namespace:opencost_ram_cost:sum{%(cluster)s, %(namespace)s}
-          )
-          * 730
-        ||| % defaultFilters,
-
         workloadCpuEfficiencyTopN: |||
           topk(10,
             workload:efficiency_cpu:ratio{%(cluster)s, %(namespace)s}
@@ -740,16 +729,6 @@ local tbOverride = tbStandardOptions.override;
             description='Namespace total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.',
           ),
 
-        monthlyWasteStat:
-          dashboards.statPanel(
-            'Monthly Waste',
-            'currencyUSD',
-            queries.namespaceMonthlyWaste,
-            graphMode='none',
-            decimals=2,
-            description='Projected monthly spend in this namespace that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h.',
-          ),
-
         workloadCpuEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
             'CPU Efficiency by Workload (Top 10)',
@@ -836,9 +815,8 @@ local tbOverride = tbStandardOptions.override;
             panels.cpuEfficiencyStat,
             panels.ramEfficiencyStat,
             panels.totalEfficiencyStat,
-            panels.monthlyWasteStat,
           ],
-          panelWidth=6,
+          panelWidth=8,
           panelHeight=3,
           startY=24
         ) +

--- a/dashboards/opencost-namespace.libsonnet
+++ b/dashboards/opencost-namespace.libsonnet
@@ -315,14 +315,14 @@ local tbOverride = tbStandardOptions.override;
         namespaceRamEfficiency: 'namespace:efficiency_ram:ratio{%(cluster)s, %(namespace)s}' % defaultFilters,
         namespaceTotalEfficiency: 'namespace:efficiency_total:ratio{%(cluster)s, %(namespace)s}' % defaultFilters,
 
-        workloadCpuEfficiencyTopN: |||
-          topk(10,
+        workloadCpuEfficiencyBottomN: |||
+          bottomk(10,
             workload:efficiency_cpu:ratio{%(cluster)s, %(namespace)s}
           )
         ||| % defaultFilters,
 
-        workloadRamEfficiencyTopN: |||
-          topk(10,
+        workloadRamEfficiencyBottomN: |||
+          bottomk(10,
             workload:efficiency_ram:ratio{%(cluster)s, %(namespace)s}
           )
         ||| % defaultFilters,
@@ -709,7 +709,8 @@ local tbOverride = tbStandardOptions.override;
             graphMode='none',
             decimals=2,
             description='CPU usage / OpenCost-exported CPU allocation for the selected namespace. Values well below 1.0 indicate allocated CPU that is not being actively used. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         ramEfficiencyStat:
           dashboards.statPanel(
@@ -719,7 +720,8 @@ local tbOverride = tbStandardOptions.override;
             graphMode='none',
             decimals=2,
             description='Working-set RAM / OpenCost-exported RAM allocation for the selected namespace. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         totalEfficiencyStat:
           dashboards.statPanel(
@@ -729,35 +731,40 @@ local tbOverride = tbStandardOptions.override;
             graphMode='none',
             decimals=2,
             description='Namespace total allocation efficiency combining CPU and RAM with CPU/RAM cost weights. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         workloadCpuEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
-            'CPU Efficiency by Workload (Top 10)',
+            'CPU Efficiency by Workload (Bottom 10)',
             'percentunit',
             [
               {
-                expr: queries.workloadCpuEfficiencyTopN,
+                expr: queries.workloadCpuEfficiencyBottomN,
                 legend: '{{workload_type}}/{{workload}}',
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='Top 10 workloads inside the selected namespace by CPU allocation efficiency. Low values indicate workloads that have been allocated more CPU than they are actively using.',
-          ),
+            calcs=['min', 'mean', 'max'],
+            description='Bottom 10 workloads inside the selected namespace by CPU allocation efficiency. Low values indicate workloads that have been allocated more CPU than they are actively using.',
+          ) +
+          util.efficiencyTimeSeriesThresholdLine($._config),
 
         workloadRamEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
-            'RAM Efficiency by Workload (Top 10)',
+            'RAM Efficiency by Workload (Bottom 10)',
             'percentunit',
             [
               {
-                expr: queries.workloadRamEfficiencyTopN,
+                expr: queries.workloadRamEfficiencyBottomN,
                 legend: '{{workload_type}}/{{workload}}',
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='Top 10 workloads inside the selected namespace by RAM allocation efficiency.',
-          ),
+            calcs=['min', 'mean', 'max'],
+            description='Bottom 10 workloads inside the selected namespace by RAM allocation efficiency.',
+          ) +
+          util.efficiencyTimeSeriesThresholdLine($._config),
       };
 
       local rows =

--- a/dashboards/opencost-namespace.libsonnet
+++ b/dashboards/opencost-namespace.libsonnet
@@ -304,9 +304,11 @@ local tbOverride = tbStandardOptions.override;
         pvMonthlyCostByPv: std.strReplace(queries.monthlyPVCost, '* 730', 'by (persistentvolume) * 730'),
         pvcMonthlyCostByClaim: std.strReplace(queries.monthlyPVCost, '* 730', 'by (persistentvolumeclaim) * 730'),
 
-        // Efficiency queries — mirror OpenCost's native CPUEfficiency, RAMEfficiency and
-        // TotalEfficiency calculation (see https://www.opencost.io/docs/specification#efficiency).
-        // Backed by the opencost.rules.efficiency recording rules shipped in this mixin.
+        // Allocation efficiency queries. OpenCost does not export native efficiency
+        // metrics, so the recording rules use OpenCost allocation metrics as
+        // denominators. This is close to the OpenCost model, but not exact UI/API
+        // parity because native CPUEfficiency/RAMEfficiency use request averages.
+        // Backed by the opencost.rules.efficiency recording rules shipped here.
         // The recording rules aggregate by (cluster, namespace) so the job label is not
         // present; queries below select by cluster+namespace only.
         namespaceCpuEfficiency: 'namespace:efficiency_cpu:ratio{%(cluster)s, %(namespace)s}' % defaultFilters,
@@ -706,7 +708,7 @@ local tbOverride = tbStandardOptions.override;
             queries.namespaceCpuEfficiency,
             graphMode='none',
             decimals=2,
-            description='CPU usage / CPU allocation for the selected namespace. Values well below 1.0 indicate containers that have been allocated more CPU than they are actually using. Mirrors the CPUEfficiency metric from the OpenCost UI.',
+            description='CPU usage / OpenCost-exported CPU allocation for the selected namespace. Values well below 1.0 indicate allocated CPU that is not being actively used. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.',
           ),
 
         ramEfficiencyStat:
@@ -716,7 +718,7 @@ local tbOverride = tbStandardOptions.override;
             queries.namespaceRamEfficiency,
             graphMode='none',
             decimals=2,
-            description='Working-set RAM / RAM allocation for the selected namespace. Mirrors the RAMEfficiency metric from the OpenCost UI.',
+            description='Working-set RAM / OpenCost-exported RAM allocation for the selected namespace. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.',
           ),
 
         totalEfficiencyStat:
@@ -726,7 +728,7 @@ local tbOverride = tbStandardOptions.override;
             queries.namespaceTotalEfficiency,
             graphMode='none',
             decimals=2,
-            description='Namespace total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.',
+            description='Namespace total allocation efficiency combining CPU and RAM with CPU/RAM cost weights. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.',
           ),
 
         workloadCpuEfficiencyTimeSeries:
@@ -740,7 +742,7 @@ local tbOverride = tbStandardOptions.override;
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='Top 10 workloads inside the selected namespace by CPU efficiency. Low values indicate workloads that have been allocated more CPU than they are actually using.',
+            description='Top 10 workloads inside the selected namespace by CPU allocation efficiency. Low values indicate workloads that have been allocated more CPU than they are actively using.',
           ),
 
         workloadRamEfficiencyTimeSeries:
@@ -754,7 +756,7 @@ local tbOverride = tbStandardOptions.override;
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='Top 10 workloads inside the selected namespace by RAM efficiency.',
+            description='Top 10 workloads inside the selected namespace by RAM allocation efficiency.',
           ),
       };
 

--- a/dashboards/opencost-overview.libsonnet
+++ b/dashboards/opencost-overview.libsonnet
@@ -349,6 +349,75 @@ local tbOverride = tbStandardOptions.override;
             * 730
           ) by (persistentvolume)
         ||| % defaultFilters,
+
+        // Efficiency queries — mirror OpenCost's native CPUEfficiency, RAMEfficiency
+        // and TotalEfficiency (cost-weighted) calculation. See
+        // https://www.opencost.io/docs/specification#efficiency and
+        // https://github.com/opencost/opencost/blob/develop/core/pkg/opencost/allocation.go.
+        // Backed by the opencost.rules.efficiency recording rules shipped in this mixin.
+        clusterCpuEfficiency: |||
+          sum(namespace:opencost_cpu_cost:sum{%(cluster)s} * namespace:efficiency_cpu:ratio{%(cluster)s})
+          /
+          sum(namespace:opencost_cpu_cost:sum{%(cluster)s})
+        ||| % defaultFilters,
+
+        clusterRamEfficiency: |||
+          sum(namespace:opencost_ram_cost:sum{%(cluster)s} * namespace:efficiency_ram:ratio{%(cluster)s})
+          /
+          sum(namespace:opencost_ram_cost:sum{%(cluster)s})
+        ||| % defaultFilters,
+
+        clusterTotalEfficiency: |||
+          (
+            sum(namespace:opencost_cpu_cost:sum{%(cluster)s} * namespace:efficiency_cpu:ratio{%(cluster)s})
+            +
+            sum(namespace:opencost_ram_cost:sum{%(cluster)s} * namespace:efficiency_ram:ratio{%(cluster)s})
+          )
+          /
+          (
+            sum(namespace:opencost_cpu_cost:sum{%(cluster)s})
+            +
+            sum(namespace:opencost_ram_cost:sum{%(cluster)s})
+          )
+        ||| % defaultFilters,
+
+        clusterMonthlyWaste: |||
+          (
+            1 -
+            (
+              (
+                sum(namespace:opencost_cpu_cost:sum{%(cluster)s} * namespace:efficiency_cpu:ratio{%(cluster)s})
+                +
+                sum(namespace:opencost_ram_cost:sum{%(cluster)s} * namespace:efficiency_ram:ratio{%(cluster)s})
+              )
+              /
+              (
+                sum(namespace:opencost_cpu_cost:sum{%(cluster)s})
+                +
+                sum(namespace:opencost_ram_cost:sum{%(cluster)s})
+              )
+            )
+          )
+          *
+          (
+            sum(namespace:opencost_cpu_cost:sum{%(cluster)s})
+            +
+            sum(namespace:opencost_ram_cost:sum{%(cluster)s})
+          )
+          * 730
+        ||| % defaultFilters,
+
+        namespaceCpuEfficiencyTopN: |||
+          topk(10,
+            namespace:efficiency_cpu:ratio{%(cluster)s}
+          )
+        ||| % defaultFilters,
+
+        namespaceRamEfficiencyTopN: |||
+          topk(10,
+            namespace:efficiency_ram:ratio{%(cluster)s}
+          )
+        ||| % defaultFilters,
       };
 
       local panels = {
@@ -727,6 +796,74 @@ local tbOverride = tbStandardOptions.override;
               tbStandardOptions.threshold.step.withColor('red'),
             ]
           ),
+
+        cpuEfficiencyStat:
+          dashboards.statPanel(
+            'CPU Efficiency',
+            'percentunit',
+            queries.clusterCpuEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='Cost-weighted average CPU efficiency across all namespaces in the cluster. Efficiency = CPU usage / CPU allocation. Values closer to 1.0 indicate that requested CPU is being actively consumed; values well below 1.0 indicate over-requested workloads that can be rightsized. Mirrors the CPUEfficiency metric from the OpenCost UI.',
+          ),
+
+        ramEfficiencyStat:
+          dashboards.statPanel(
+            'RAM Efficiency',
+            'percentunit',
+            queries.clusterRamEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='Cost-weighted average memory efficiency across all namespaces in the cluster. Efficiency = working-set RAM / RAM allocation. Mirrors the RAMEfficiency metric from the OpenCost UI.',
+          ),
+
+        totalEfficiencyStat:
+          dashboards.statPanel(
+            'Total Efficiency',
+            'percentunit',
+            queries.clusterTotalEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='Cluster total (cost-weighted) efficiency combining CPU and RAM: (CPUCost × CPUEff + RAMCost × RAMEff) / (CPUCost + RAMCost). Mirrors the TotalEfficiency metric from the OpenCost UI.',
+          ),
+
+        monthlyWasteStat:
+          dashboards.statPanel(
+            'Monthly Waste',
+            'currencyUSD',
+            queries.clusterMonthlyWaste,
+            graphMode='none',
+            decimals=2,
+            description='Projected monthly spend that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h. Represents the theoretical savings if all requests were perfectly sized to actual usage.',
+          ),
+
+        namespaceCpuEfficiencyTimeSeries:
+          dashboards.timeSeriesPanel(
+            'CPU Efficiency by Namespace (Top 10)',
+            'percentunit',
+            [
+              {
+                expr: queries.namespaceCpuEfficiencyTopN,
+                legend: '{{namespace}}',
+                interval: $._config.dashboardMinInterval,
+              },
+            ],
+            description='Top 10 namespaces by CPU efficiency. Low values indicate namespaces that have been allocated more CPU than they are actually using.',
+          ),
+
+        namespaceRamEfficiencyTimeSeries:
+          dashboards.timeSeriesPanel(
+            'RAM Efficiency by Namespace (Top 10)',
+            'percentunit',
+            [
+              {
+                expr: queries.namespaceRamEfficiencyTopN,
+                legend: '{{namespace}}',
+                interval: $._config.dashboardMinInterval,
+              },
+            ],
+            description='Top 10 namespaces by RAM efficiency. Low values indicate namespaces whose containers have memory requests well above their working-set usage.',
+          ),
       };
 
       local rows =
@@ -779,31 +916,58 @@ local tbOverride = tbStandardOptions.override;
           startY=15
         ) +
         [
-          row.new('Cloud Resources') +
+          row.new('Efficiency') +
           row.gridPos.withX(0) +
           row.gridPos.withY(20) +
+          row.gridPos.withW(24) +
+          row.gridPos.withH(1),
+        ] +
+        grid.wrapPanels(
+          [
+            panels.cpuEfficiencyStat,
+            panels.ramEfficiencyStat,
+            panels.totalEfficiencyStat,
+            panels.monthlyWasteStat,
+          ],
+          panelWidth=6,
+          panelHeight=3,
+          startY=21
+        ) +
+        grid.wrapPanels(
+          [
+            panels.namespaceCpuEfficiencyTimeSeries,
+            panels.namespaceRamEfficiencyTimeSeries,
+          ],
+          panelWidth=12,
+          panelHeight=5,
+          startY=24
+        ) +
+        [
+          row.new('Cloud Resources') +
+          row.gridPos.withX(0) +
+          row.gridPos.withY(29) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1),
         ] +
         [
           panels.nodeTable +
           tablePanel.gridPos.withX(0) +
-          tablePanel.gridPos.withY(21) +
+          tablePanel.gridPos.withY(30) +
           tablePanel.gridPos.withW(16) +
           tablePanel.gridPos.withH(10),
           panels.pvTable +
           tablePanel.gridPos.withX(16) +
-          tablePanel.gridPos.withY(21) +
+          tablePanel.gridPos.withY(30) +
           tablePanel.gridPos.withW(8) +
           tablePanel.gridPos.withH(10),
           row.new('Namespace Summary') +
           row.gridPos.withX(0) +
-          row.gridPos.withY(31) +
+          row.gridPos.withY(40) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1),
           panels.namespaceTable +
           tablePanel.gridPos.withX(0) +
-          tablePanel.gridPos.withY(32) +
+          tablePanel.gridPos.withY(41) +
           tablePanel.gridPos.withW(24) +
           tablePanel.gridPos.withH(12),
         ];

--- a/dashboards/opencost-overview.libsonnet
+++ b/dashboards/opencost-overview.libsonnet
@@ -381,14 +381,14 @@ local tbOverride = tbStandardOptions.override;
           )
         ||| % defaultFilters,
 
-        namespaceCpuEfficiencyTopN: |||
-          topk(10,
+        namespaceCpuEfficiencyBottomN: |||
+          bottomk(10,
             namespace:efficiency_cpu:ratio{%(cluster)s}
           )
         ||| % defaultFilters,
 
-        namespaceRamEfficiencyTopN: |||
-          topk(10,
+        namespaceRamEfficiencyBottomN: |||
+          bottomk(10,
             namespace:efficiency_ram:ratio{%(cluster)s}
           )
         ||| % defaultFilters,
@@ -779,7 +779,8 @@ local tbOverride = tbStandardOptions.override;
             graphMode='none',
             decimals=2,
             description='Cost-weighted average CPU allocation efficiency across all namespaces in the cluster. This is CPU usage / OpenCost-exported CPU allocation. Values well below 1.0 indicate allocated CPU that is not being actively used. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         ramEfficiencyStat:
           dashboards.statPanel(
@@ -789,7 +790,8 @@ local tbOverride = tbStandardOptions.override;
             graphMode='none',
             decimals=2,
             description='Cost-weighted average RAM allocation efficiency across all namespaces in the cluster. This is working-set RAM / OpenCost-exported RAM allocation. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         totalEfficiencyStat:
           dashboards.statPanel(
@@ -799,35 +801,40 @@ local tbOverride = tbStandardOptions.override;
             graphMode='none',
             decimals=2,
             description='Cluster total allocation efficiency combining CPU and RAM: (CPUCost × CPUAllocationEfficiency + RAMCost × RAMAllocationEfficiency) / (CPUCost + RAMCost). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         namespaceCpuEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
-            'CPU Efficiency by Namespace (Top 10)',
+            'CPU Efficiency by Namespace (Bottom 10)',
             'percentunit',
             [
               {
-                expr: queries.namespaceCpuEfficiencyTopN,
+                expr: queries.namespaceCpuEfficiencyBottomN,
                 legend: '{{namespace}}',
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='Top 10 namespaces by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.',
-          ),
+            calcs=['min', 'mean', 'max'],
+            description='Bottom 10 namespaces by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.',
+          ) +
+          util.efficiencyTimeSeriesThresholdLine($._config),
 
         namespaceRamEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
-            'RAM Efficiency by Namespace (Top 10)',
+            'RAM Efficiency by Namespace (Bottom 10)',
             'percentunit',
             [
               {
-                expr: queries.namespaceRamEfficiencyTopN,
+                expr: queries.namespaceRamEfficiencyBottomN,
                 legend: '{{namespace}}',
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='Top 10 namespaces by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.',
-          ),
+            calcs=['min', 'mean', 'max'],
+            description='Bottom 10 namespaces by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.',
+          ) +
+          util.efficiencyTimeSeriesThresholdLine($._config),
       };
 
       local rows =

--- a/dashboards/opencost-overview.libsonnet
+++ b/dashboards/opencost-overview.libsonnet
@@ -355,43 +355,113 @@ local tbOverride = tbStandardOptions.override;
         // denominators. This is close to the OpenCost model, but not exact UI/API
         // parity because native CPUEfficiency/RAMEfficiency use request averages.
         // Backed by the opencost.rules.efficiency recording rules shipped here.
-        clusterCpuEfficiency: |||
-          sum(namespace:opencost_cpu_cost:sum{%(cluster)s} * namespace:efficiency_cpu:ratio{%(cluster)s})
-          /
-          sum(namespace:opencost_cpu_cost:sum{%(cluster)s})
+        namespaceMonthlyCpuRamCost: |||
+          (
+            namespace:opencost_cpu_cost:sum{%(cluster)s}
+            +
+            namespace:opencost_ram_cost:sum{%(cluster)s}
+          ) * 730
         ||| % defaultFilters,
+
+        namespaceEfficiencyCostFilter: |||
+          %(namespaceMonthlyCpuRamCost)s > %(minMonthlyCostThreshold)s
+        ||| % {
+          namespaceMonthlyCpuRamCost: queries.namespaceMonthlyCpuRamCost,
+          minMonthlyCostThreshold: $._config.alerts.efficiency.minMonthlyCostThreshold,
+        },
+
+        clusterCpuEfficiency: |||
+          sum(
+            (
+              namespace:opencost_cpu_cost:sum{%(cluster)s}
+              *
+              namespace:efficiency_cpu:ratio{%(cluster)s}
+            )
+            and on(%(clusterLabel)s, namespace)
+            (%(namespaceEfficiencyCostFilter)s)
+          )
+          /
+          sum(
+            namespace:opencost_cpu_cost:sum{%(cluster)s}
+            and on(%(clusterLabel)s, namespace)
+            (%(namespaceEfficiencyCostFilter)s)
+          )
+        ||| % (defaultFilters {
+                 clusterLabel: $._config.clusterLabel,
+                 namespaceEfficiencyCostFilter: queries.namespaceEfficiencyCostFilter,
+               }),
 
         clusterRamEfficiency: |||
-          sum(namespace:opencost_ram_cost:sum{%(cluster)s} * namespace:efficiency_ram:ratio{%(cluster)s})
+          sum(
+            (
+              namespace:opencost_ram_cost:sum{%(cluster)s}
+              *
+              namespace:efficiency_ram:ratio{%(cluster)s}
+            )
+            and on(%(clusterLabel)s, namespace)
+            (%(namespaceEfficiencyCostFilter)s)
+          )
           /
-          sum(namespace:opencost_ram_cost:sum{%(cluster)s})
-        ||| % defaultFilters,
+          sum(
+            namespace:opencost_ram_cost:sum{%(cluster)s}
+            and on(%(clusterLabel)s, namespace)
+            (%(namespaceEfficiencyCostFilter)s)
+          )
+        ||| % (defaultFilters {
+                 clusterLabel: $._config.clusterLabel,
+                 namespaceEfficiencyCostFilter: queries.namespaceEfficiencyCostFilter,
+               }),
 
         clusterTotalEfficiency: |||
-          (
-            sum(namespace:opencost_cpu_cost:sum{%(cluster)s} * namespace:efficiency_cpu:ratio{%(cluster)s})
-            +
-            sum(namespace:opencost_ram_cost:sum{%(cluster)s} * namespace:efficiency_ram:ratio{%(cluster)s})
+          sum(
+            (
+              namespace:opencost_cpu_cost:sum{%(cluster)s}
+              *
+              namespace:efficiency_cpu:ratio{%(cluster)s}
+              +
+              namespace:opencost_ram_cost:sum{%(cluster)s}
+              *
+              namespace:efficiency_ram:ratio{%(cluster)s}
+            )
+            and on(%(clusterLabel)s, namespace)
+            (%(namespaceEfficiencyCostFilter)s)
           )
           /
-          (
-            sum(namespace:opencost_cpu_cost:sum{%(cluster)s})
-            +
-            sum(namespace:opencost_ram_cost:sum{%(cluster)s})
+          sum(
+            (
+              namespace:opencost_cpu_cost:sum{%(cluster)s}
+              +
+              namespace:opencost_ram_cost:sum{%(cluster)s}
+            )
+            and on(%(clusterLabel)s, namespace)
+            (%(namespaceEfficiencyCostFilter)s)
           )
-        ||| % defaultFilters,
+        ||| % (defaultFilters {
+                 clusterLabel: $._config.clusterLabel,
+                 namespaceEfficiencyCostFilter: queries.namespaceEfficiencyCostFilter,
+               }),
 
         namespaceCpuEfficiencyBottomN: |||
           bottomk(10,
             namespace:efficiency_cpu:ratio{%(cluster)s}
+            and on(%(clusterLabel)s, namespace)
+            (%(namespaceEfficiencyCostFilter)s)
           )
-        ||| % defaultFilters,
+        ||| % (defaultFilters {
+                 clusterLabel: $._config.clusterLabel,
+                 namespaceEfficiencyCostFilter: queries.namespaceEfficiencyCostFilter,
+               }),
 
         namespaceRamEfficiencyBottomN: |||
           bottomk(10,
             namespace:efficiency_ram:ratio{%(cluster)s}
+            and on(%(clusterLabel)s, namespace)
+            (%(namespaceEfficiencyCostFilter)s)
           )
-        ||| % defaultFilters,
+        ||| % (defaultFilters {
+                 clusterLabel: $._config.clusterLabel,
+                 namespaceEfficiencyCostFilter: queries.namespaceEfficiencyCostFilter,
+               }),
       };
 
       local panels = {
@@ -778,7 +848,7 @@ local tbOverride = tbStandardOptions.override;
             queries.clusterCpuEfficiency,
             graphMode='none',
             decimals=2,
-            description='Cost-weighted average CPU allocation efficiency across all namespaces in the cluster. This is CPU usage / OpenCost-exported CPU allocation. Values well below 1.0 indicate allocated CPU that is not being actively used. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.',
+            description='Cost-weighted average CPU allocation efficiency across namespaces above the projected monthly CPU+RAM cost threshold. This is CPU usage / OpenCost-exported CPU allocation. Values well below 1.0 indicate allocated CPU that is not being actively used. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.',
           ) +
           util.efficiencyStatThresholds($._config),
 
@@ -789,7 +859,7 @@ local tbOverride = tbStandardOptions.override;
             queries.clusterRamEfficiency,
             graphMode='none',
             decimals=2,
-            description='Cost-weighted average RAM allocation efficiency across all namespaces in the cluster. This is working-set RAM / OpenCost-exported RAM allocation. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.',
+            description='Cost-weighted average RAM allocation efficiency across namespaces above the projected monthly CPU+RAM cost threshold. This is working-set RAM / OpenCost-exported RAM allocation. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.',
           ) +
           util.efficiencyStatThresholds($._config),
 
@@ -800,7 +870,7 @@ local tbOverride = tbStandardOptions.override;
             queries.clusterTotalEfficiency,
             graphMode='none',
             decimals=2,
-            description='Cluster total allocation efficiency combining CPU and RAM: (CPUCost × CPUAllocationEfficiency + RAMCost × RAMAllocationEfficiency) / (CPUCost + RAMCost). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.',
+            description='Cluster total allocation efficiency across namespaces above the projected monthly CPU+RAM cost threshold, combining CPU and RAM: (CPUCost × CPUAllocationEfficiency + RAMCost × RAMAllocationEfficiency) / (CPUCost + RAMCost). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.',
           ) +
           util.efficiencyStatThresholds($._config),
 
@@ -816,7 +886,7 @@ local tbOverride = tbStandardOptions.override;
               },
             ],
             calcs=['min', 'mean', 'max'],
-            description='Bottom 10 namespaces by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.',
+            description='Bottom 10 namespaces above the projected monthly CPU+RAM cost threshold by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.',
           ) +
           util.efficiencyTimeSeriesThresholdLine($._config),
 
@@ -832,7 +902,7 @@ local tbOverride = tbStandardOptions.override;
               },
             ],
             calcs=['min', 'mean', 'max'],
-            description='Bottom 10 namespaces by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.',
+            description='Bottom 10 namespaces above the projected monthly CPU+RAM cost threshold by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.',
           ) +
           util.efficiencyTimeSeriesThresholdLine($._config),
       };

--- a/dashboards/opencost-overview.libsonnet
+++ b/dashboards/opencost-overview.libsonnet
@@ -350,11 +350,11 @@ local tbOverride = tbStandardOptions.override;
           ) by (persistentvolume)
         ||| % defaultFilters,
 
-        // Efficiency queries — mirror OpenCost's native CPUEfficiency, RAMEfficiency
-        // and TotalEfficiency (cost-weighted) calculation. See
-        // https://www.opencost.io/docs/specification#efficiency and
-        // https://github.com/opencost/opencost/blob/develop/core/pkg/opencost/allocation.go.
-        // Backed by the opencost.rules.efficiency recording rules shipped in this mixin.
+        // Allocation efficiency queries. OpenCost does not export native efficiency
+        // metrics, so the recording rules use OpenCost allocation metrics as
+        // denominators. This is close to the OpenCost model, but not exact UI/API
+        // parity because native CPUEfficiency/RAMEfficiency use request averages.
+        // Backed by the opencost.rules.efficiency recording rules shipped here.
         clusterCpuEfficiency: |||
           sum(namespace:opencost_cpu_cost:sum{%(cluster)s} * namespace:efficiency_cpu:ratio{%(cluster)s})
           /
@@ -778,7 +778,7 @@ local tbOverride = tbStandardOptions.override;
             queries.clusterCpuEfficiency,
             graphMode='none',
             decimals=2,
-            description='Cost-weighted average CPU efficiency across all namespaces in the cluster. Efficiency = CPU usage / CPU allocation. Values closer to 1.0 indicate that requested CPU is being actively consumed; values well below 1.0 indicate over-requested workloads that can be rightsized. Mirrors the CPUEfficiency metric from the OpenCost UI.',
+            description='Cost-weighted average CPU allocation efficiency across all namespaces in the cluster. This is CPU usage / OpenCost-exported CPU allocation. Values well below 1.0 indicate allocated CPU that is not being actively used. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.',
           ),
 
         ramEfficiencyStat:
@@ -788,7 +788,7 @@ local tbOverride = tbStandardOptions.override;
             queries.clusterRamEfficiency,
             graphMode='none',
             decimals=2,
-            description='Cost-weighted average memory efficiency across all namespaces in the cluster. Efficiency = working-set RAM / RAM allocation. Mirrors the RAMEfficiency metric from the OpenCost UI.',
+            description='Cost-weighted average RAM allocation efficiency across all namespaces in the cluster. This is working-set RAM / OpenCost-exported RAM allocation. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.',
           ),
 
         totalEfficiencyStat:
@@ -798,7 +798,7 @@ local tbOverride = tbStandardOptions.override;
             queries.clusterTotalEfficiency,
             graphMode='none',
             decimals=2,
-            description='Cluster total (cost-weighted) efficiency combining CPU and RAM: (CPUCost × CPUEff + RAMCost × RAMEff) / (CPUCost + RAMCost). Mirrors the TotalEfficiency metric from the OpenCost UI.',
+            description='Cluster total allocation efficiency combining CPU and RAM: (CPUCost × CPUAllocationEfficiency + RAMCost × RAMAllocationEfficiency) / (CPUCost + RAMCost). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.',
           ),
 
         namespaceCpuEfficiencyTimeSeries:
@@ -812,7 +812,7 @@ local tbOverride = tbStandardOptions.override;
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='Top 10 namespaces by CPU efficiency. Low values indicate namespaces that have been allocated more CPU than they are actually using.',
+            description='Top 10 namespaces by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.',
           ),
 
         namespaceRamEfficiencyTimeSeries:
@@ -826,7 +826,7 @@ local tbOverride = tbStandardOptions.override;
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='Top 10 namespaces by RAM efficiency. Low values indicate namespaces whose containers have memory requests well above their working-set usage.',
+            description='Top 10 namespaces by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.',
           ),
       };
 

--- a/dashboards/opencost-overview.libsonnet
+++ b/dashboards/opencost-overview.libsonnet
@@ -381,32 +381,6 @@ local tbOverride = tbStandardOptions.override;
           )
         ||| % defaultFilters,
 
-        clusterMonthlyWaste: |||
-          (
-            1 -
-            (
-              (
-                sum(namespace:opencost_cpu_cost:sum{%(cluster)s} * namespace:efficiency_cpu:ratio{%(cluster)s})
-                +
-                sum(namespace:opencost_ram_cost:sum{%(cluster)s} * namespace:efficiency_ram:ratio{%(cluster)s})
-              )
-              /
-              (
-                sum(namespace:opencost_cpu_cost:sum{%(cluster)s})
-                +
-                sum(namespace:opencost_ram_cost:sum{%(cluster)s})
-              )
-            )
-          )
-          *
-          (
-            sum(namespace:opencost_cpu_cost:sum{%(cluster)s})
-            +
-            sum(namespace:opencost_ram_cost:sum{%(cluster)s})
-          )
-          * 730
-        ||| % defaultFilters,
-
         namespaceCpuEfficiencyTopN: |||
           topk(10,
             namespace:efficiency_cpu:ratio{%(cluster)s}
@@ -827,16 +801,6 @@ local tbOverride = tbStandardOptions.override;
             description='Cluster total (cost-weighted) efficiency combining CPU and RAM: (CPUCost × CPUEff + RAMCost × RAMEff) / (CPUCost + RAMCost). Mirrors the TotalEfficiency metric from the OpenCost UI.',
           ),
 
-        monthlyWasteStat:
-          dashboards.statPanel(
-            'Monthly Waste',
-            'currencyUSD',
-            queries.clusterMonthlyWaste,
-            graphMode='none',
-            decimals=2,
-            description='Projected monthly spend that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h. Represents the theoretical savings if all requests were perfectly sized to actual usage.',
-          ),
-
         namespaceCpuEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
             'CPU Efficiency by Namespace (Top 10)',
@@ -927,9 +891,8 @@ local tbOverride = tbStandardOptions.override;
             panels.cpuEfficiencyStat,
             panels.ramEfficiencyStat,
             panels.totalEfficiencyStat,
-            panels.monthlyWasteStat,
           ],
-          panelWidth=6,
+          panelWidth=8,
           panelHeight=3,
           startY=21
         ) +

--- a/dashboards/opencost-workload.libsonnet
+++ b/dashboards/opencost-workload.libsonnet
@@ -175,6 +175,26 @@ local tbQueryOptions = tablePanel.queryOptions;
           ) by (pod)
         ||| % ($._config { workloadFilters: workloadFilters }),
 
+        // Efficiency queries — mirror OpenCost's native CPUEfficiency, RAMEfficiency and
+        // TotalEfficiency calculation (see https://www.opencost.io/docs/specification#efficiency).
+        // Backed by the workload:efficiency_*:ratio recording rules shipped in this mixin.
+        workloadCpuEfficiency: 'workload:efficiency_cpu:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
+        workloadRamEfficiency: 'workload:efficiency_ram:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
+        workloadTotalEfficiency: 'workload:efficiency_total:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
+
+        workloadMonthlyWaste: |||
+          (1 - workload:efficiency_total:ratio{%(withNamespaceWorkload)s})
+          *
+          (
+            workload:opencost_cpu_cost:sum{%(withNamespaceWorkload)s}
+            +
+            workload:opencost_ram_cost:sum{%(withNamespaceWorkload)s}
+          )
+          * 730
+        ||| % defaultFilters,
+
+        workloadCpuEfficiencyTimeSeriesQuery: 'workload:efficiency_cpu:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
+        workloadRamEfficiencyTimeSeriesQuery: 'workload:efficiency_ram:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
       };
 
       local panels = {
@@ -443,6 +463,74 @@ local tbQueryOptions = tablePanel.queryOptions;
               ),
             ]
           ),
+
+        cpuEfficiencyStat:
+          dashboards.statPanel(
+            'CPU Efficiency',
+            'percentunit',
+            queries.workloadCpuEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='CPU usage / CPU allocation for the selected workload(s). Values well below 1.0 indicate containers allocated more CPU than they are actually using. Mirrors CPUEfficiency from the OpenCost UI.',
+          ),
+
+        ramEfficiencyStat:
+          dashboards.statPanel(
+            'RAM Efficiency',
+            'percentunit',
+            queries.workloadRamEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='Working-set RAM / RAM allocation for the selected workload(s). Mirrors RAMEfficiency from the OpenCost UI.',
+          ),
+
+        totalEfficiencyStat:
+          dashboards.statPanel(
+            'Total Efficiency',
+            'percentunit',
+            queries.workloadTotalEfficiency,
+            graphMode='none',
+            decimals=2,
+            description='Workload total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.',
+          ),
+
+        monthlyWasteStat:
+          dashboards.statPanel(
+            'Monthly Waste',
+            'currencyUSD',
+            queries.workloadMonthlyWaste,
+            graphMode='none',
+            decimals=2,
+            description='Projected monthly spend for the selected workload(s) that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h.',
+          ),
+
+        cpuEfficiencyTimeSeries:
+          dashboards.timeSeriesPanel(
+            'CPU Efficiency',
+            'percentunit',
+            [
+              {
+                expr: queries.workloadCpuEfficiencyTimeSeriesQuery,
+                legend: '{{workload_type}}/{{workload}}',
+                interval: $._config.dashboardMinInterval,
+              },
+            ],
+            description='CPU efficiency over time for the selected workload(s).',
+          ),
+
+        ramEfficiencyTimeSeries:
+          dashboards.timeSeriesPanel(
+            'RAM Efficiency',
+            'percentunit',
+            [
+              {
+                expr: queries.workloadRamEfficiencyTimeSeriesQuery,
+                legend: '{{workload_type}}/{{workload}}',
+                interval: $._config.dashboardMinInterval,
+              },
+            ],
+            description='RAM efficiency over time for the selected workload(s).',
+          ),
       };
 
       local rows =
@@ -486,24 +574,51 @@ local tbQueryOptions = tablePanel.queryOptions;
           startY=10
         ) +
         [
-          row.new('Workload Breakdown') +
+          row.new('Efficiency') +
           row.gridPos.withX(0) +
           row.gridPos.withY(25) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1),
+        ] +
+        grid.wrapPanels(
+          [
+            panels.cpuEfficiencyStat,
+            panels.ramEfficiencyStat,
+            panels.totalEfficiencyStat,
+            panels.monthlyWasteStat,
+          ],
+          panelWidth=6,
+          panelHeight=3,
+          startY=26
+        ) +
+        grid.wrapPanels(
+          [
+            panels.cpuEfficiencyTimeSeries,
+            panels.ramEfficiencyTimeSeries,
+          ],
+          panelWidth=12,
+          panelHeight=5,
+          startY=29
+        ) +
+        [
+          row.new('Workload Breakdown') +
+          row.gridPos.withX(0) +
+          row.gridPos.withY(34) +
+          row.gridPos.withW(24) +
+          row.gridPos.withH(1),
           panels.workloadTable +
           tablePanel.gridPos.withX(0) +
-          tablePanel.gridPos.withY(26) +
+          tablePanel.gridPos.withY(35) +
           tablePanel.gridPos.withW(24) +
           tablePanel.gridPos.withH(10),
           row.new('Persistent Volume Claims') +
           row.gridPos.withX(0) +
-          row.gridPos.withY(36) +
+          row.gridPos.withY(45) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1),
           panels.pvcTable +
           tablePanel.gridPos.withX(0) +
-          tablePanel.gridPos.withY(37) +
+          tablePanel.gridPos.withY(46) +
           tablePanel.gridPos.withW(24) +
           tablePanel.gridPos.withH(8),
         ];

--- a/dashboards/opencost-workload.libsonnet
+++ b/dashboards/opencost-workload.libsonnet
@@ -175,9 +175,11 @@ local tbQueryOptions = tablePanel.queryOptions;
           ) by (pod)
         ||| % ($._config { workloadFilters: workloadFilters }),
 
-        // Efficiency queries — mirror OpenCost's native CPUEfficiency, RAMEfficiency and
-        // TotalEfficiency calculation (see https://www.opencost.io/docs/specification#efficiency).
-        // Backed by the workload:efficiency_*:ratio recording rules shipped in this mixin.
+        // Allocation efficiency queries. OpenCost does not export native efficiency
+        // metrics, so the recording rules use OpenCost allocation metrics as
+        // denominators. This is close to the OpenCost model, but not exact UI/API
+        // parity because native CPUEfficiency/RAMEfficiency use request averages.
+        // Backed by the workload:efficiency_*:ratio recording rules shipped here.
         workloadCpuEfficiency: 'workload:efficiency_cpu:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
         workloadRamEfficiency: 'workload:efficiency_ram:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
         workloadTotalEfficiency: 'workload:efficiency_total:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
@@ -460,7 +462,7 @@ local tbQueryOptions = tablePanel.queryOptions;
             queries.workloadCpuEfficiency,
             graphMode='none',
             decimals=2,
-            description='CPU usage / CPU allocation for the selected workload(s). Values well below 1.0 indicate containers allocated more CPU than they are actually using. Mirrors CPUEfficiency from the OpenCost UI.',
+            description='CPU usage / OpenCost-exported CPU allocation for the selected workload(s). Values well below 1.0 indicate allocated CPU that is not being actively used. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.',
           ),
 
         ramEfficiencyStat:
@@ -470,7 +472,7 @@ local tbQueryOptions = tablePanel.queryOptions;
             queries.workloadRamEfficiency,
             graphMode='none',
             decimals=2,
-            description='Working-set RAM / RAM allocation for the selected workload(s). Mirrors RAMEfficiency from the OpenCost UI.',
+            description='Working-set RAM / OpenCost-exported RAM allocation for the selected workload(s). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.',
           ),
 
         totalEfficiencyStat:
@@ -480,7 +482,7 @@ local tbQueryOptions = tablePanel.queryOptions;
             queries.workloadTotalEfficiency,
             graphMode='none',
             decimals=2,
-            description='Workload total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.',
+            description='Workload total allocation efficiency combining CPU and RAM with CPU/RAM cost weights. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.',
           ),
 
         cpuEfficiencyTimeSeries:
@@ -494,7 +496,7 @@ local tbQueryOptions = tablePanel.queryOptions;
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='CPU efficiency over time for the selected workload(s).',
+            description='CPU allocation efficiency over time for the selected workload(s).',
           ),
 
         ramEfficiencyTimeSeries:
@@ -508,7 +510,7 @@ local tbQueryOptions = tablePanel.queryOptions;
                 interval: $._config.dashboardMinInterval,
               },
             ],
-            description='RAM efficiency over time for the selected workload(s).',
+            description='RAM allocation efficiency over time for the selected workload(s).',
           ),
       };
 

--- a/dashboards/opencost-workload.libsonnet
+++ b/dashboards/opencost-workload.libsonnet
@@ -463,7 +463,8 @@ local tbQueryOptions = tablePanel.queryOptions;
             graphMode='none',
             decimals=2,
             description='CPU usage / OpenCost-exported CPU allocation for the selected workload(s). Values well below 1.0 indicate allocated CPU that is not being actively used. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         ramEfficiencyStat:
           dashboards.statPanel(
@@ -473,7 +474,8 @@ local tbQueryOptions = tablePanel.queryOptions;
             graphMode='none',
             decimals=2,
             description='Working-set RAM / OpenCost-exported RAM allocation for the selected workload(s). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         totalEfficiencyStat:
           dashboards.statPanel(
@@ -483,7 +485,8 @@ local tbQueryOptions = tablePanel.queryOptions;
             graphMode='none',
             decimals=2,
             description='Workload total allocation efficiency combining CPU and RAM with CPU/RAM cost weights. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.',
-          ),
+          ) +
+          util.efficiencyStatThresholds($._config),
 
         cpuEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
@@ -496,8 +499,10 @@ local tbQueryOptions = tablePanel.queryOptions;
                 interval: $._config.dashboardMinInterval,
               },
             ],
+            calcs=['min', 'mean', 'max'],
             description='CPU allocation efficiency over time for the selected workload(s).',
-          ),
+          ) +
+          util.efficiencyTimeSeriesThresholdLine($._config),
 
         ramEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
@@ -510,8 +515,10 @@ local tbQueryOptions = tablePanel.queryOptions;
                 interval: $._config.dashboardMinInterval,
               },
             ],
+            calcs=['min', 'mean', 'max'],
             description='RAM allocation efficiency over time for the selected workload(s).',
-          ),
+          ) +
+          util.efficiencyTimeSeriesThresholdLine($._config),
       };
 
       local rows =

--- a/dashboards/opencost-workload.libsonnet
+++ b/dashboards/opencost-workload.libsonnet
@@ -182,17 +182,6 @@ local tbQueryOptions = tablePanel.queryOptions;
         workloadRamEfficiency: 'workload:efficiency_ram:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
         workloadTotalEfficiency: 'workload:efficiency_total:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
 
-        workloadMonthlyWaste: |||
-          (1 - workload:efficiency_total:ratio{%(withNamespaceWorkload)s})
-          *
-          (
-            workload:opencost_cpu_cost:sum{%(withNamespaceWorkload)s}
-            +
-            workload:opencost_ram_cost:sum{%(withNamespaceWorkload)s}
-          )
-          * 730
-        ||| % defaultFilters,
-
         workloadCpuEfficiencyTimeSeriesQuery: 'workload:efficiency_cpu:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
         workloadRamEfficiencyTimeSeriesQuery: 'workload:efficiency_ram:ratio{%(withNamespaceWorkload)s}' % defaultFilters,
       };
@@ -494,16 +483,6 @@ local tbQueryOptions = tablePanel.queryOptions;
             description='Workload total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.',
           ),
 
-        monthlyWasteStat:
-          dashboards.statPanel(
-            'Monthly Waste',
-            'currencyUSD',
-            queries.workloadMonthlyWaste,
-            graphMode='none',
-            decimals=2,
-            description='Projected monthly spend for the selected workload(s) that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h.',
-          ),
-
         cpuEfficiencyTimeSeries:
           dashboards.timeSeriesPanel(
             'CPU Efficiency',
@@ -585,9 +564,8 @@ local tbQueryOptions = tablePanel.queryOptions;
             panels.cpuEfficiencyStat,
             panels.ramEfficiencyStat,
             panels.totalEfficiencyStat,
-            panels.monthlyWasteStat,
           ],
-          panelWidth=6,
+          panelWidth=8,
           panelHeight=3,
           startY=26
         ) +

--- a/dashboards/util.libsonnet
+++ b/dashboards/util.libsonnet
@@ -1,10 +1,16 @@
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 
 local dashboard = g.dashboard;
+local stat = g.panel.stat;
+local timeSeries = g.panel.timeSeries;
 
 local variable = dashboard.variable;
 local datasource = variable.datasource;
 local query = variable.query;
+local stStandardOptions = stat.standardOptions;
+local tsCustom = timeSeries.fieldConfig.defaults.custom;
+local tsLegend = timeSeries.options.legend;
+local tsStandardOptions = timeSeries.standardOptions;
 
 {
   filters(config):: {
@@ -126,4 +132,19 @@ local query = variable.query;
       query.generalOptions.showOnDashboard.withLabelAndValue() +
       query.withSort(type='alphabetical'),
   },
+
+  efficiencyThresholdSteps(config):: [
+    stStandardOptions.threshold.step.withColor('red'),
+    stStandardOptions.threshold.step.withValue(config.alerts.efficiency.minEfficiencyThreshold) +
+    stStandardOptions.threshold.step.withColor('green'),
+  ],
+
+  efficiencyStatThresholds(config)::
+    stStandardOptions.color.withMode('thresholds') +
+    stStandardOptions.thresholds.withSteps(self.efficiencyThresholdSteps(config)),
+
+  efficiencyTimeSeriesThresholdLine(config)::
+    tsStandardOptions.thresholds.withSteps(self.efficiencyThresholdSteps(config)) +
+    tsCustom.thresholdsStyle.withMode('line') +
+    tsLegend.withSortDesc(false),
 }

--- a/dashboards_out/opencost-namespace.json
+++ b/dashboards_out/opencost-namespace.json
@@ -675,6 +675,320 @@
             "y": 23
          },
          "id": 14,
+         "title": "Efficiency",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "CPU usage / CPU allocation for the selected namespace. Values well below 1.0 indicate containers that have been allocated more CPU than they are actually using. Mirrors the CPUEfficiency metric from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 0,
+            "y": 24
+         },
+         "id": 15,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "namespace:efficiency_cpu:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}",
+               "instant": false
+            }
+         ],
+         "title": "CPU Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Working-set RAM / RAM allocation for the selected namespace. Mirrors the RAMEfficiency metric from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 6,
+            "y": 24
+         },
+         "id": 16,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "namespace:efficiency_ram:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}",
+               "instant": false
+            }
+         ],
+         "title": "RAM Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Namespace total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 24
+         },
+         "id": 17,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "namespace:efficiency_total:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}",
+               "instant": false
+            }
+         ],
+         "title": "Total Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly spend in this namespace that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 24
+         },
+         "id": 18,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(1 - namespace:efficiency_total:ratio{cluster=\"$cluster\", namespace=\"$namespace\"})\n*\n(\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\", namespace=\"$namespace\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\", namespace=\"$namespace\"}\n)\n* 730\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Waste",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 workloads inside the selected namespace by CPU efficiency. Low values indicate workloads that have been allocated more CPU than they are actually using.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 27
+         },
+         "id": 19,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "topk(10,\n  workload:efficiency_cpu:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}\n)\n",
+               "interval": "30m",
+               "legendFormat": "{{workload_type}}/{{workload}}"
+            }
+         ],
+         "title": "CPU Efficiency by Workload (Top 10)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 workloads inside the selected namespace by RAM efficiency.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 27
+         },
+         "id": 20,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "topk(10,\n  workload:efficiency_ram:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}\n)\n",
+               "interval": "30m",
+               "legendFormat": "{{workload_type}}/{{workload}}"
+            }
+         ],
+         "title": "RAM Efficiency by Workload (Top 10)",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 32
+         },
+         "id": 21,
          "title": "Pod Summary",
          "type": "row"
       },
@@ -760,9 +1074,9 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 24
+            "y": 33
          },
-         "id": 15,
+         "id": 22,
          "options": {
             "footer": {
                "enablePagination": true
@@ -839,9 +1153,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 43
          },
-         "id": 16,
+         "id": 23,
          "title": "Container Summary",
          "type": "row"
       },
@@ -927,9 +1241,9 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 44
          },
-         "id": 17,
+         "id": 24,
          "options": {
             "footer": {
                "enablePagination": true
@@ -1006,9 +1320,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 45
+            "y": 54
          },
-         "id": 18,
+         "id": 25,
          "title": "PV Summary",
          "type": "row"
       },
@@ -1045,9 +1359,9 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 46
+            "y": 55
          },
-         "id": 19,
+         "id": 26,
          "options": {
             "footer": {
                "enablePagination": true

--- a/dashboards_out/opencost-namespace.json
+++ b/dashboards_out/opencost-namespace.json
@@ -683,7 +683,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "CPU usage / CPU allocation for the selected namespace. Values well below 1.0 indicate containers that have been allocated more CPU than they are actually using. Mirrors the CPUEfficiency metric from the OpenCost UI.",
+         "description": "CPU usage / OpenCost-exported CPU allocation for the selected namespace. Values well below 1.0 indicate allocated CPU that is not being actively used. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -731,7 +731,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Working-set RAM / RAM allocation for the selected namespace. Mirrors the RAMEfficiency metric from the OpenCost UI.",
+         "description": "Working-set RAM / OpenCost-exported RAM allocation for the selected namespace. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -779,7 +779,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Namespace total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.",
+         "description": "Namespace total allocation efficiency combining CPU and RAM with CPU/RAM cost weights. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -827,7 +827,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Top 10 workloads inside the selected namespace by CPU efficiency. Low values indicate workloads that have been allocated more CPU than they are actually using.",
+         "description": "Top 10 workloads inside the selected namespace by CPU allocation efficiency. Low values indicate workloads that have been allocated more CPU than they are actively using.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -882,7 +882,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Top 10 workloads inside the selected namespace by RAM efficiency.",
+         "description": "Top 10 workloads inside the selected namespace by RAM allocation efficiency.",
          "fieldConfig": {
             "defaults": {
                "custom": {

--- a/dashboards_out/opencost-namespace.json
+++ b/dashboards_out/opencost-namespace.json
@@ -686,13 +686,19 @@
          "description": "CPU usage / OpenCost-exported CPU allocation for the selected namespace. Values well below 1.0 indicate allocated CPU that is not being actively used. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -734,13 +740,19 @@
          "description": "Working-set RAM / OpenCost-exported RAM allocation for the selected namespace. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -782,13 +794,19 @@
          "description": "Namespace total allocation efficiency combining CPU and RAM with CPU/RAM cost weights. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -827,11 +845,25 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Top 10 workloads inside the selected namespace by CPU allocation efficiency. Low values indicate workloads that have been allocated more CPU than they are actively using.",
+         "description": "Bottom 10 workloads inside the selected namespace by CPU allocation efficiency. Low values indicate workloads that have been allocated more CPU than they are actively using.",
          "fieldConfig": {
             "defaults": {
                "custom": {
-                  "fillOpacity": 10
+                  "fillOpacity": 10,
+                  "thresholdsStyle": {
+                     "mode": "line"
+                  }
+               },
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "red"
+                     },
+                     {
+                        "color": "green",
+                        "value": 0.20000000000000001
+                     }
+                  ]
                },
                "unit": "percentunit"
             },
@@ -847,14 +879,15 @@
          "options": {
             "legend": {
                "calcs": [
+                  "min",
                   "mean",
                   "max"
                ],
                "displayMode": "table",
                "placement": "right",
                "showLegend": true,
-               "sortBy": "Mean",
-               "sortDesc": true
+               "sortBy": "Min",
+               "sortDesc": false
             },
             "tooltip": {
                "mode": "multi",
@@ -869,12 +902,12 @@
                   "uid": "$datasource"
                },
                "exemplar": false,
-               "expr": "topk(10,\n  workload:efficiency_cpu:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}\n)\n",
+               "expr": "bottomk(10,\n  workload:efficiency_cpu:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}\n)\n",
                "interval": "30m",
                "legendFormat": "{{workload_type}}/{{workload}}"
             }
          ],
-         "title": "CPU Efficiency by Workload (Top 10)",
+         "title": "CPU Efficiency by Workload (Bottom 10)",
          "type": "timeseries"
       },
       {
@@ -882,11 +915,25 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Top 10 workloads inside the selected namespace by RAM allocation efficiency.",
+         "description": "Bottom 10 workloads inside the selected namespace by RAM allocation efficiency.",
          "fieldConfig": {
             "defaults": {
                "custom": {
-                  "fillOpacity": 10
+                  "fillOpacity": 10,
+                  "thresholdsStyle": {
+                     "mode": "line"
+                  }
+               },
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "red"
+                     },
+                     {
+                        "color": "green",
+                        "value": 0.20000000000000001
+                     }
+                  ]
                },
                "unit": "percentunit"
             },
@@ -902,14 +949,15 @@
          "options": {
             "legend": {
                "calcs": [
+                  "min",
                   "mean",
                   "max"
                ],
                "displayMode": "table",
                "placement": "right",
                "showLegend": true,
-               "sortBy": "Mean",
-               "sortDesc": true
+               "sortBy": "Min",
+               "sortDesc": false
             },
             "tooltip": {
                "mode": "multi",
@@ -924,12 +972,12 @@
                   "uid": "$datasource"
                },
                "exemplar": false,
-               "expr": "topk(10,\n  workload:efficiency_ram:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}\n)\n",
+               "expr": "bottomk(10,\n  workload:efficiency_ram:ratio{cluster=\"$cluster\", namespace=\"$namespace\"}\n)\n",
                "interval": "30m",
                "legendFormat": "{{workload_type}}/{{workload}}"
             }
          ],
-         "title": "RAM Efficiency by Workload (Top 10)",
+         "title": "RAM Efficiency by Workload (Bottom 10)",
          "type": "timeseries"
       },
       {

--- a/dashboards_out/opencost-namespace.json
+++ b/dashboards_out/opencost-namespace.json
@@ -702,7 +702,7 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
+            "w": 8,
             "x": 0,
             "y": 24
          },
@@ -750,8 +750,8 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
-            "x": 6,
+            "w": 8,
+            "x": 8,
             "y": 24
          },
          "id": 16,
@@ -798,8 +798,8 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
-            "x": 12,
+            "w": 8,
+            "x": 16,
             "y": 24
          },
          "id": 17,
@@ -827,54 +827,6 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Projected monthly spend in this namespace that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h.",
-         "fieldConfig": {
-            "defaults": {
-               "decimals": 2,
-               "mappings": [ ],
-               "thresholds": {
-                  "steps": [
-                     {
-                        "color": "green",
-                        "value": 0
-                     }
-                  ]
-               },
-               "unit": "currencyUSD"
-            },
-            "overrides": [ ]
-         },
-         "gridPos": {
-            "h": 3,
-            "w": 6,
-            "x": 18,
-            "y": 24
-         },
-         "id": 18,
-         "options": {
-            "graphMode": "none",
-            "percentChangeColorMode": "standard",
-            "showPercentChange": false
-         },
-         "pluginVersion": "v11.4.0",
-         "targets": [
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "$datasource"
-               },
-               "expr": "(1 - namespace:efficiency_total:ratio{cluster=\"$cluster\", namespace=\"$namespace\"})\n*\n(\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\", namespace=\"$namespace\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\", namespace=\"$namespace\"}\n)\n* 730\n",
-               "instant": false
-            }
-         ],
-         "title": "Monthly Waste",
-         "type": "stat"
-      },
-      {
-         "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-         },
          "description": "Top 10 workloads inside the selected namespace by CPU efficiency. Low values indicate workloads that have been allocated more CPU than they are actually using.",
          "fieldConfig": {
             "defaults": {
@@ -891,7 +843,7 @@
             "x": 0,
             "y": 27
          },
-         "id": 19,
+         "id": 18,
          "options": {
             "legend": {
                "calcs": [
@@ -946,7 +898,7 @@
             "x": 12,
             "y": 27
          },
-         "id": 20,
+         "id": 19,
          "options": {
             "legend": {
                "calcs": [
@@ -988,7 +940,7 @@
             "x": 0,
             "y": 32
          },
-         "id": 21,
+         "id": 20,
          "title": "Pod Summary",
          "type": "row"
       },
@@ -1076,7 +1028,7 @@
             "x": 0,
             "y": 33
          },
-         "id": 22,
+         "id": 21,
          "options": {
             "footer": {
                "enablePagination": true
@@ -1155,7 +1107,7 @@
             "x": 0,
             "y": 43
          },
-         "id": 23,
+         "id": 22,
          "title": "Container Summary",
          "type": "row"
       },
@@ -1243,7 +1195,7 @@
             "x": 0,
             "y": 44
          },
-         "id": 24,
+         "id": 23,
          "options": {
             "footer": {
                "enablePagination": true
@@ -1322,7 +1274,7 @@
             "x": 0,
             "y": 54
          },
-         "id": 25,
+         "id": 24,
          "title": "PV Summary",
          "type": "row"
       },
@@ -1361,7 +1313,7 @@
             "x": 0,
             "y": 55
          },
-         "id": 26,
+         "id": 25,
          "options": {
             "footer": {
                "enablePagination": true

--- a/dashboards_out/opencost-overview.json
+++ b/dashboards_out/opencost-overview.json
@@ -762,6 +762,320 @@
             "y": 20
          },
          "id": 15,
+         "title": "Efficiency",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Cost-weighted average CPU efficiency across all namespaces in the cluster. Efficiency = CPU usage / CPU allocation. Values closer to 1.0 indicate that requested CPU is being actively consumed; values well below 1.0 indicate over-requested workloads that can be rightsized. Mirrors the CPUEfficiency metric from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 0,
+            "y": 21
+         },
+         "id": 16,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_cpu:ratio{cluster=\"$cluster\"})\n/\nsum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"})\n",
+               "instant": false
+            }
+         ],
+         "title": "CPU Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Cost-weighted average memory efficiency across all namespaces in the cluster. Efficiency = working-set RAM / RAM allocation. Mirrors the RAMEfficiency metric from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 6,
+            "y": 21
+         },
+         "id": 17,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_ram:ratio{cluster=\"$cluster\"})\n/\nsum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"})\n",
+               "instant": false
+            }
+         ],
+         "title": "RAM Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Cluster total (cost-weighted) efficiency combining CPU and RAM: (CPUCost × CPUEff + RAMCost × RAMEff) / (CPUCost + RAMCost). Mirrors the TotalEfficiency metric from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 21
+         },
+         "id": 18,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(\n  sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_cpu:ratio{cluster=\"$cluster\"})\n  +\n  sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_ram:ratio{cluster=\"$cluster\"})\n)\n/\n(\n  sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"})\n  +\n  sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"})\n)\n",
+               "instant": false
+            }
+         ],
+         "title": "Total Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly spend that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h. Represents the theoretical savings if all requests were perfectly sized to actual usage.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 21
+         },
+         "id": 19,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(\n  1 -\n  (\n    (\n      sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_cpu:ratio{cluster=\"$cluster\"})\n      +\n      sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_ram:ratio{cluster=\"$cluster\"})\n    )\n    /\n    (\n      sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"})\n      +\n      sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"})\n    )\n  )\n)\n*\n(\n  sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"})\n  +\n  sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"})\n)\n* 730\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Waste",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 namespaces by CPU efficiency. Low values indicate namespaces that have been allocated more CPU than they are actually using.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 24
+         },
+         "id": 20,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "topk(10,\n  namespace:efficiency_cpu:ratio{cluster=\"$cluster\"}\n)\n",
+               "interval": "30m",
+               "legendFormat": "{{namespace}}"
+            }
+         ],
+         "title": "CPU Efficiency by Namespace (Top 10)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Top 10 namespaces by RAM efficiency. Low values indicate namespaces whose containers have memory requests well above their working-set usage.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 24
+         },
+         "id": 21,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "topk(10,\n  namespace:efficiency_ram:ratio{cluster=\"$cluster\"}\n)\n",
+               "interval": "30m",
+               "legendFormat": "{{namespace}}"
+            }
+         ],
+         "title": "RAM Efficiency by Namespace (Top 10)",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 29
+         },
+         "id": 22,
          "title": "Cloud Resources",
          "type": "row"
       },
@@ -785,9 +1099,9 @@
             "h": 10,
             "w": 16,
             "x": 0,
-            "y": 21
+            "y": 30
          },
-         "id": 16,
+         "id": 23,
          "options": {
             "footer": {
                "enablePagination": true
@@ -895,9 +1209,9 @@
             "h": 10,
             "w": 8,
             "x": 16,
-            "y": 21
+            "y": 30
          },
-         "id": 17,
+         "id": 24,
          "options": {
             "footer": {
                "enablePagination": true
@@ -963,9 +1277,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 31
+            "y": 40
          },
-         "id": 18,
+         "id": 25,
          "title": "Namespace Summary",
          "type": "row"
       },
@@ -1070,9 +1384,9 @@
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 32
+            "y": 41
          },
-         "id": 19,
+         "id": 26,
          "options": {
             "footer": {
                "enablePagination": true

--- a/dashboards_out/opencost-overview.json
+++ b/dashboards_out/opencost-overview.json
@@ -770,7 +770,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Cost-weighted average CPU efficiency across all namespaces in the cluster. Efficiency = CPU usage / CPU allocation. Values closer to 1.0 indicate that requested CPU is being actively consumed; values well below 1.0 indicate over-requested workloads that can be rightsized. Mirrors the CPUEfficiency metric from the OpenCost UI.",
+         "description": "Cost-weighted average CPU allocation efficiency across all namespaces in the cluster. This is CPU usage / OpenCost-exported CPU allocation. Values well below 1.0 indicate allocated CPU that is not being actively used. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -818,7 +818,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Cost-weighted average memory efficiency across all namespaces in the cluster. Efficiency = working-set RAM / RAM allocation. Mirrors the RAMEfficiency metric from the OpenCost UI.",
+         "description": "Cost-weighted average RAM allocation efficiency across all namespaces in the cluster. This is working-set RAM / OpenCost-exported RAM allocation. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -866,7 +866,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Cluster total (cost-weighted) efficiency combining CPU and RAM: (CPUCost × CPUEff + RAMCost × RAMEff) / (CPUCost + RAMCost). Mirrors the TotalEfficiency metric from the OpenCost UI.",
+         "description": "Cluster total allocation efficiency combining CPU and RAM: (CPUCost × CPUAllocationEfficiency + RAMCost × RAMAllocationEfficiency) / (CPUCost + RAMCost). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -914,7 +914,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Top 10 namespaces by CPU efficiency. Low values indicate namespaces that have been allocated more CPU than they are actually using.",
+         "description": "Top 10 namespaces by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -969,7 +969,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Top 10 namespaces by RAM efficiency. Low values indicate namespaces whose containers have memory requests well above their working-set usage.",
+         "description": "Top 10 namespaces by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.",
          "fieldConfig": {
             "defaults": {
                "custom": {

--- a/dashboards_out/opencost-overview.json
+++ b/dashboards_out/opencost-overview.json
@@ -770,7 +770,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Cost-weighted average CPU allocation efficiency across all namespaces in the cluster. This is CPU usage / OpenCost-exported CPU allocation. Values well below 1.0 indicate allocated CPU that is not being actively used. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.",
+         "description": "Cost-weighted average CPU allocation efficiency across namespaces above the projected monthly CPU+RAM cost threshold. This is CPU usage / OpenCost-exported CPU allocation. Values well below 1.0 indicate allocated CPU that is not being actively used. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.",
          "fieldConfig": {
             "defaults": {
                "color": {
@@ -812,7 +812,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_cpu:ratio{cluster=\"$cluster\"})\n/\nsum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"})\n",
+               "expr": "sum(\n  (\n    namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n    *\n    namespace:efficiency_cpu:ratio{cluster=\"$cluster\"}\n  )\n  and on(cluster, namespace)\n  ((\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n) * 730\n > 100\n)\n)\n/\nsum(\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  and on(cluster, namespace)\n  ((\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n) * 730\n > 100\n)\n)\n",
                "instant": false
             }
          ],
@@ -824,7 +824,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Cost-weighted average RAM allocation efficiency across all namespaces in the cluster. This is working-set RAM / OpenCost-exported RAM allocation. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.",
+         "description": "Cost-weighted average RAM allocation efficiency across namespaces above the projected monthly CPU+RAM cost threshold. This is working-set RAM / OpenCost-exported RAM allocation. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.",
          "fieldConfig": {
             "defaults": {
                "color": {
@@ -866,7 +866,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_ram:ratio{cluster=\"$cluster\"})\n/\nsum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"})\n",
+               "expr": "sum(\n  (\n    namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n    *\n    namespace:efficiency_ram:ratio{cluster=\"$cluster\"}\n  )\n  and on(cluster, namespace)\n  ((\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n) * 730\n > 100\n)\n)\n/\nsum(\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n  and on(cluster, namespace)\n  ((\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n) * 730\n > 100\n)\n)\n",
                "instant": false
             }
          ],
@@ -878,7 +878,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Cluster total allocation efficiency combining CPU and RAM: (CPUCost × CPUAllocationEfficiency + RAMCost × RAMAllocationEfficiency) / (CPUCost + RAMCost). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.",
+         "description": "Cluster total allocation efficiency across namespaces above the projected monthly CPU+RAM cost threshold, combining CPU and RAM: (CPUCost × CPUAllocationEfficiency + RAMCost × RAMAllocationEfficiency) / (CPUCost + RAMCost). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.",
          "fieldConfig": {
             "defaults": {
                "color": {
@@ -920,7 +920,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "(\n  sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_cpu:ratio{cluster=\"$cluster\"})\n  +\n  sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_ram:ratio{cluster=\"$cluster\"})\n)\n/\n(\n  sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"})\n  +\n  sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"})\n)\n",
+               "expr": "sum(\n  (\n    namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n    *\n    namespace:efficiency_cpu:ratio{cluster=\"$cluster\"}\n    +\n    namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n    *\n    namespace:efficiency_ram:ratio{cluster=\"$cluster\"}\n  )\n  and on(cluster, namespace)\n  ((\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n) * 730\n > 100\n)\n)\n/\nsum(\n  (\n    namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n    +\n    namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n  )\n  and on(cluster, namespace)\n  ((\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n) * 730\n > 100\n)\n)\n",
                "instant": false
             }
          ],
@@ -932,7 +932,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Bottom 10 namespaces by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.",
+         "description": "Bottom 10 namespaces above the projected monthly CPU+RAM cost threshold by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -989,7 +989,7 @@
                   "uid": "$datasource"
                },
                "exemplar": false,
-               "expr": "bottomk(10,\n  namespace:efficiency_cpu:ratio{cluster=\"$cluster\"}\n)\n",
+               "expr": "bottomk(10,\n  namespace:efficiency_cpu:ratio{cluster=\"$cluster\"}\n  and on(cluster, namespace)\n  ((\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n) * 730\n > 100\n)\n)\n",
                "interval": "30m",
                "legendFormat": "{{namespace}}"
             }
@@ -1002,7 +1002,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Bottom 10 namespaces by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.",
+         "description": "Bottom 10 namespaces above the projected monthly CPU+RAM cost threshold by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -1059,7 +1059,7 @@
                   "uid": "$datasource"
                },
                "exemplar": false,
-               "expr": "bottomk(10,\n  namespace:efficiency_ram:ratio{cluster=\"$cluster\"}\n)\n",
+               "expr": "bottomk(10,\n  namespace:efficiency_ram:ratio{cluster=\"$cluster\"}\n  and on(cluster, namespace)\n  ((\n  namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"}\n  +\n  namespace:opencost_ram_cost:sum{cluster=\"$cluster\"}\n) * 730\n > 100\n)\n)\n",
                "interval": "30m",
                "legendFormat": "{{namespace}}"
             }

--- a/dashboards_out/opencost-overview.json
+++ b/dashboards_out/opencost-overview.json
@@ -773,13 +773,19 @@
          "description": "Cost-weighted average CPU allocation efficiency across all namespaces in the cluster. This is CPU usage / OpenCost-exported CPU allocation. Values well below 1.0 indicate allocated CPU that is not being actively used. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -821,13 +827,19 @@
          "description": "Cost-weighted average RAM allocation efficiency across all namespaces in the cluster. This is working-set RAM / OpenCost-exported RAM allocation. It is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -869,13 +881,19 @@
          "description": "Cluster total allocation efficiency combining CPU and RAM: (CPUCost × CPUAllocationEfficiency + RAMCost × RAMAllocationEfficiency) / (CPUCost + RAMCost). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -914,11 +932,25 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Top 10 namespaces by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.",
+         "description": "Bottom 10 namespaces by CPU allocation efficiency. Low values indicate namespaces that have been allocated more CPU than they are actively using.",
          "fieldConfig": {
             "defaults": {
                "custom": {
-                  "fillOpacity": 10
+                  "fillOpacity": 10,
+                  "thresholdsStyle": {
+                     "mode": "line"
+                  }
+               },
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "red"
+                     },
+                     {
+                        "color": "green",
+                        "value": 0.20000000000000001
+                     }
+                  ]
                },
                "unit": "percentunit"
             },
@@ -934,14 +966,15 @@
          "options": {
             "legend": {
                "calcs": [
+                  "min",
                   "mean",
                   "max"
                ],
                "displayMode": "table",
                "placement": "right",
                "showLegend": true,
-               "sortBy": "Mean",
-               "sortDesc": true
+               "sortBy": "Min",
+               "sortDesc": false
             },
             "tooltip": {
                "mode": "multi",
@@ -956,12 +989,12 @@
                   "uid": "$datasource"
                },
                "exemplar": false,
-               "expr": "topk(10,\n  namespace:efficiency_cpu:ratio{cluster=\"$cluster\"}\n)\n",
+               "expr": "bottomk(10,\n  namespace:efficiency_cpu:ratio{cluster=\"$cluster\"}\n)\n",
                "interval": "30m",
                "legendFormat": "{{namespace}}"
             }
          ],
-         "title": "CPU Efficiency by Namespace (Top 10)",
+         "title": "CPU Efficiency by Namespace (Bottom 10)",
          "type": "timeseries"
       },
       {
@@ -969,11 +1002,25 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Top 10 namespaces by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.",
+         "description": "Bottom 10 namespaces by RAM allocation efficiency. Low values indicate namespaces whose allocated memory is above their working-set usage.",
          "fieldConfig": {
             "defaults": {
                "custom": {
-                  "fillOpacity": 10
+                  "fillOpacity": 10,
+                  "thresholdsStyle": {
+                     "mode": "line"
+                  }
+               },
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "red"
+                     },
+                     {
+                        "color": "green",
+                        "value": 0.20000000000000001
+                     }
+                  ]
                },
                "unit": "percentunit"
             },
@@ -989,14 +1036,15 @@
          "options": {
             "legend": {
                "calcs": [
+                  "min",
                   "mean",
                   "max"
                ],
                "displayMode": "table",
                "placement": "right",
                "showLegend": true,
-               "sortBy": "Mean",
-               "sortDesc": true
+               "sortBy": "Min",
+               "sortDesc": false
             },
             "tooltip": {
                "mode": "multi",
@@ -1011,12 +1059,12 @@
                   "uid": "$datasource"
                },
                "exemplar": false,
-               "expr": "topk(10,\n  namespace:efficiency_ram:ratio{cluster=\"$cluster\"}\n)\n",
+               "expr": "bottomk(10,\n  namespace:efficiency_ram:ratio{cluster=\"$cluster\"}\n)\n",
                "interval": "30m",
                "legendFormat": "{{namespace}}"
             }
          ],
-         "title": "RAM Efficiency by Namespace (Top 10)",
+         "title": "RAM Efficiency by Namespace (Bottom 10)",
          "type": "timeseries"
       },
       {

--- a/dashboards_out/opencost-overview.json
+++ b/dashboards_out/opencost-overview.json
@@ -789,7 +789,7 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
+            "w": 8,
             "x": 0,
             "y": 21
          },
@@ -837,8 +837,8 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
-            "x": 6,
+            "w": 8,
+            "x": 8,
             "y": 21
          },
          "id": 17,
@@ -885,8 +885,8 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
-            "x": 12,
+            "w": 8,
+            "x": 16,
             "y": 21
          },
          "id": 18,
@@ -914,54 +914,6 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Projected monthly spend that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h. Represents the theoretical savings if all requests were perfectly sized to actual usage.",
-         "fieldConfig": {
-            "defaults": {
-               "decimals": 2,
-               "mappings": [ ],
-               "thresholds": {
-                  "steps": [
-                     {
-                        "color": "green",
-                        "value": 0
-                     }
-                  ]
-               },
-               "unit": "currencyUSD"
-            },
-            "overrides": [ ]
-         },
-         "gridPos": {
-            "h": 3,
-            "w": 6,
-            "x": 18,
-            "y": 21
-         },
-         "id": 19,
-         "options": {
-            "graphMode": "none",
-            "percentChangeColorMode": "standard",
-            "showPercentChange": false
-         },
-         "pluginVersion": "v11.4.0",
-         "targets": [
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "$datasource"
-               },
-               "expr": "(\n  1 -\n  (\n    (\n      sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_cpu:ratio{cluster=\"$cluster\"})\n      +\n      sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"} * namespace:efficiency_ram:ratio{cluster=\"$cluster\"})\n    )\n    /\n    (\n      sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"})\n      +\n      sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"})\n    )\n  )\n)\n*\n(\n  sum(namespace:opencost_cpu_cost:sum{cluster=\"$cluster\"})\n  +\n  sum(namespace:opencost_ram_cost:sum{cluster=\"$cluster\"})\n)\n* 730\n",
-               "instant": false
-            }
-         ],
-         "title": "Monthly Waste",
-         "type": "stat"
-      },
-      {
-         "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-         },
          "description": "Top 10 namespaces by CPU efficiency. Low values indicate namespaces that have been allocated more CPU than they are actually using.",
          "fieldConfig": {
             "defaults": {
@@ -978,7 +930,7 @@
             "x": 0,
             "y": 24
          },
-         "id": 20,
+         "id": 19,
          "options": {
             "legend": {
                "calcs": [
@@ -1033,7 +985,7 @@
             "x": 12,
             "y": 24
          },
-         "id": 21,
+         "id": 20,
          "options": {
             "legend": {
                "calcs": [
@@ -1075,7 +1027,7 @@
             "x": 0,
             "y": 29
          },
-         "id": 22,
+         "id": 21,
          "title": "Cloud Resources",
          "type": "row"
       },
@@ -1101,7 +1053,7 @@
             "x": 0,
             "y": 30
          },
-         "id": 23,
+         "id": 22,
          "options": {
             "footer": {
                "enablePagination": true
@@ -1211,7 +1163,7 @@
             "x": 16,
             "y": 30
          },
-         "id": 24,
+         "id": 23,
          "options": {
             "footer": {
                "enablePagination": true
@@ -1279,7 +1231,7 @@
             "x": 0,
             "y": 40
          },
-         "id": 25,
+         "id": 24,
          "title": "Namespace Summary",
          "type": "row"
       },
@@ -1386,7 +1338,7 @@
             "x": 0,
             "y": 41
          },
-         "id": 26,
+         "id": 25,
          "options": {
             "footer": {
                "enablePagination": true

--- a/dashboards_out/opencost-workload.json
+++ b/dashboards_out/opencost-workload.json
@@ -663,6 +663,320 @@
             "y": 25
          },
          "id": 13,
+         "title": "Efficiency",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "CPU usage / CPU allocation for the selected workload(s). Values well below 1.0 indicate containers allocated more CPU than they are actually using. Mirrors CPUEfficiency from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 0,
+            "y": 26
+         },
+         "id": 14,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "workload:efficiency_cpu:ratio{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}",
+               "instant": false
+            }
+         ],
+         "title": "CPU Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Working-set RAM / RAM allocation for the selected workload(s). Mirrors RAMEfficiency from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 6,
+            "y": 26
+         },
+         "id": 15,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "workload:efficiency_ram:ratio{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}",
+               "instant": false
+            }
+         ],
+         "title": "RAM Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Workload total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 26
+         },
+         "id": 16,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "workload:efficiency_total:ratio{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}",
+               "instant": false
+            }
+         ],
+         "title": "Total Efficiency",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Projected monthly spend for the selected workload(s) that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h.",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 2,
+               "mappings": [ ],
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     }
+                  ]
+               },
+               "unit": "currencyUSD"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 26
+         },
+         "id": 17,
+         "options": {
+            "graphMode": "none",
+            "percentChangeColorMode": "standard",
+            "showPercentChange": false
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "(1 - workload:efficiency_total:ratio{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n})\n*\n(\n  workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}\n  +\n  workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}\n)\n* 730\n",
+               "instant": false
+            }
+         ],
+         "title": "Monthly Waste",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "CPU efficiency over time for the selected workload(s).",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 29
+         },
+         "id": 18,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "workload:efficiency_cpu:ratio{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}",
+               "interval": "30m",
+               "legendFormat": "{{workload_type}}/{{workload}}"
+            }
+         ],
+         "title": "CPU Efficiency",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "RAM efficiency over time for the selected workload(s).",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "unit": "percentunit"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 29
+         },
+         "id": 19,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "workload:efficiency_ram:ratio{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}",
+               "interval": "30m",
+               "legendFormat": "{{workload_type}}/{{workload}}"
+            }
+         ],
+         "title": "RAM Efficiency",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 34
+         },
+         "id": 20,
          "title": "Workload Breakdown",
          "type": "row"
       },
@@ -686,9 +1000,9 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 26
+            "y": 35
          },
-         "id": 14,
+         "id": 21,
          "options": {
             "footer": {
                "enablePagination": true
@@ -790,9 +1104,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 36
+            "y": 45
          },
-         "id": 15,
+         "id": 22,
          "title": "Persistent Volume Claims",
          "type": "row"
       },
@@ -816,9 +1130,9 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 37
+            "y": 46
          },
-         "id": 16,
+         "id": 23,
          "options": {
             "footer": {
                "enablePagination": true

--- a/dashboards_out/opencost-workload.json
+++ b/dashboards_out/opencost-workload.json
@@ -690,7 +690,7 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
+            "w": 8,
             "x": 0,
             "y": 26
          },
@@ -738,8 +738,8 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
-            "x": 6,
+            "w": 8,
+            "x": 8,
             "y": 26
          },
          "id": 15,
@@ -786,8 +786,8 @@
          },
          "gridPos": {
             "h": 3,
-            "w": 6,
-            "x": 12,
+            "w": 8,
+            "x": 16,
             "y": 26
          },
          "id": 16,
@@ -815,54 +815,6 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Projected monthly spend for the selected workload(s) that is currently idle (allocated but unused): (1 - Total Efficiency) × (CPU Cost + RAM Cost) × 730h.",
-         "fieldConfig": {
-            "defaults": {
-               "decimals": 2,
-               "mappings": [ ],
-               "thresholds": {
-                  "steps": [
-                     {
-                        "color": "green",
-                        "value": 0
-                     }
-                  ]
-               },
-               "unit": "currencyUSD"
-            },
-            "overrides": [ ]
-         },
-         "gridPos": {
-            "h": 3,
-            "w": 6,
-            "x": 18,
-            "y": 26
-         },
-         "id": 17,
-         "options": {
-            "graphMode": "none",
-            "percentChangeColorMode": "standard",
-            "showPercentChange": false
-         },
-         "pluginVersion": "v11.4.0",
-         "targets": [
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "$datasource"
-               },
-               "expr": "(1 - workload:efficiency_total:ratio{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n})\n*\n(\n  workload:opencost_cpu_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}\n  +\n  workload:opencost_ram_cost:sum{cluster=\"$cluster\",\nnamespace=\"$namespace\",\nworkload_type=~\"$workload_type\",\nworkload=~\"$workload\"\n}\n)\n* 730\n",
-               "instant": false
-            }
-         ],
-         "title": "Monthly Waste",
-         "type": "stat"
-      },
-      {
-         "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-         },
          "description": "CPU efficiency over time for the selected workload(s).",
          "fieldConfig": {
             "defaults": {
@@ -879,7 +831,7 @@
             "x": 0,
             "y": 29
          },
-         "id": 18,
+         "id": 17,
          "options": {
             "legend": {
                "calcs": [
@@ -934,7 +886,7 @@
             "x": 12,
             "y": 29
          },
-         "id": 19,
+         "id": 18,
          "options": {
             "legend": {
                "calcs": [
@@ -976,7 +928,7 @@
             "x": 0,
             "y": 34
          },
-         "id": 20,
+         "id": 19,
          "title": "Workload Breakdown",
          "type": "row"
       },
@@ -1002,7 +954,7 @@
             "x": 0,
             "y": 35
          },
-         "id": 21,
+         "id": 20,
          "options": {
             "footer": {
                "enablePagination": true
@@ -1106,7 +1058,7 @@
             "x": 0,
             "y": 45
          },
-         "id": 22,
+         "id": 21,
          "title": "Persistent Volume Claims",
          "type": "row"
       },
@@ -1132,7 +1084,7 @@
             "x": 0,
             "y": 46
          },
-         "id": 23,
+         "id": 22,
          "options": {
             "footer": {
                "enablePagination": true

--- a/dashboards_out/opencost-workload.json
+++ b/dashboards_out/opencost-workload.json
@@ -674,13 +674,19 @@
          "description": "CPU usage / OpenCost-exported CPU allocation for the selected workload(s). Values well below 1.0 indicate allocated CPU that is not being actively used. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -722,13 +728,19 @@
          "description": "Working-set RAM / OpenCost-exported RAM allocation for the selected workload(s). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -770,13 +782,19 @@
          "description": "Workload total allocation efficiency combining CPU and RAM with CPU/RAM cost weights. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.",
          "fieldConfig": {
             "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
                "decimals": 2,
                "mappings": [ ],
                "thresholds": {
                   "steps": [
                      {
+                        "color": "red"
+                     },
+                     {
                         "color": "green",
-                        "value": 0
+                        "value": 0.20000000000000001
                      }
                   ]
                },
@@ -819,7 +837,21 @@
          "fieldConfig": {
             "defaults": {
                "custom": {
-                  "fillOpacity": 10
+                  "fillOpacity": 10,
+                  "thresholdsStyle": {
+                     "mode": "line"
+                  }
+               },
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "red"
+                     },
+                     {
+                        "color": "green",
+                        "value": 0.20000000000000001
+                     }
+                  ]
                },
                "unit": "percentunit"
             },
@@ -835,14 +867,15 @@
          "options": {
             "legend": {
                "calcs": [
+                  "min",
                   "mean",
                   "max"
                ],
                "displayMode": "table",
                "placement": "right",
                "showLegend": true,
-               "sortBy": "Mean",
-               "sortDesc": true
+               "sortBy": "Min",
+               "sortDesc": false
             },
             "tooltip": {
                "mode": "multi",
@@ -874,7 +907,21 @@
          "fieldConfig": {
             "defaults": {
                "custom": {
-                  "fillOpacity": 10
+                  "fillOpacity": 10,
+                  "thresholdsStyle": {
+                     "mode": "line"
+                  }
+               },
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "red"
+                     },
+                     {
+                        "color": "green",
+                        "value": 0.20000000000000001
+                     }
+                  ]
                },
                "unit": "percentunit"
             },
@@ -890,14 +937,15 @@
          "options": {
             "legend": {
                "calcs": [
+                  "min",
                   "mean",
                   "max"
                ],
                "displayMode": "table",
                "placement": "right",
                "showLegend": true,
-               "sortBy": "Mean",
-               "sortDesc": true
+               "sortBy": "Min",
+               "sortDesc": false
             },
             "tooltip": {
                "mode": "multi",

--- a/dashboards_out/opencost-workload.json
+++ b/dashboards_out/opencost-workload.json
@@ -671,7 +671,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "CPU usage / CPU allocation for the selected workload(s). Values well below 1.0 indicate containers allocated more CPU than they are actually using. Mirrors CPUEfficiency from the OpenCost UI.",
+         "description": "CPU usage / OpenCost-exported CPU allocation for the selected workload(s). Values well below 1.0 indicate allocated CPU that is not being actively used. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based CPUEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -719,7 +719,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Working-set RAM / RAM allocation for the selected workload(s). Mirrors RAMEfficiency from the OpenCost UI.",
+         "description": "Working-set RAM / OpenCost-exported RAM allocation for the selected workload(s). This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based RAMEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -767,7 +767,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "Workload total (cost-weighted) efficiency combining CPU and RAM. Mirrors TotalEfficiency from the OpenCost UI.",
+         "description": "Workload total allocation efficiency combining CPU and RAM with CPU/RAM cost weights. This is based on OpenCost metrics, but is not exact OpenCost UI/API request-based TotalEfficiency.",
          "fieldConfig": {
             "defaults": {
                "decimals": 2,
@@ -815,7 +815,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "CPU efficiency over time for the selected workload(s).",
+         "description": "CPU allocation efficiency over time for the selected workload(s).",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -870,7 +870,7 @@
             "type": "prometheus",
             "uid": "$datasource"
          },
-         "description": "RAM efficiency over time for the selected workload(s).",
+         "description": "RAM allocation efficiency over time for the selected workload(s).",
          "fieldConfig": {
             "defaults": {
                "custom": {

--- a/prometheus_alerts.yaml
+++ b/prometheus_alerts.yaml
@@ -141,3 +141,20 @@
     "for": "10m"
     "labels":
       "severity": "warning"
+- "name": "opencost-efficiency"
+  "rules":
+  - "alert": "OpenCostLowEfficiencyNamespace"
+    "annotations":
+      "dashboard_url": "https://grafana.com/d/opencost-mixin-namespace-jkwq/opencost-namespace"
+      "description": "Total CPU+RAM cost-weighted efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has averaged {{ $value | humanizePercentage }} over the last 7 days while projected monthly cost exceeds $500. Consider rightsizing container requests. Formula mirrors OpenCost allocation.go (CPUEfficiency, RAMEfficiency, TotalEfficiency) — spec at https://www.opencost.io/docs/specification#efficiency."
+      "summary": "Namespace {{ $labels.namespace }} on {{ $labels.cluster }} is chronically under-utilizing its requests"
+    "expr": |
+      avg_over_time(namespace:efficiency_total:ratio[7d]) < 0.20000000000000001
+      and
+      (
+        avg_over_time(namespace:opencost_cpu_cost:sum[7d])
+        + avg_over_time(namespace:opencost_ram_cost:sum[7d])
+      ) * 730 > 500
+    "for": "1h"
+    "labels":
+      "severity": "info"

--- a/prometheus_alerts.yaml
+++ b/prometheus_alerts.yaml
@@ -146,10 +146,20 @@
   - "alert": "OpenCostLowEfficiencyNamespace"
     "annotations":
       "dashboard_url": "https://grafana.com/d/opencost-mixin-namespace-jkwq/opencost-namespace"
-      "description": "Total CPU+RAM cost-weighted allocation efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has averaged {{ $value | humanizePercentage }} over the last 7 days. This is usage divided by OpenCost-exported allocation, not exact OpenCost UI/API request-based efficiency. Consider rightsizing container requests."
+      "description": "Total CPU+RAM cost-weighted allocation efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has averaged {{ $value | humanizePercentage }} over the last 7 days, with projected monthly CPU+RAM cost above $100. This is usage divided by OpenCost-exported allocation, not exact OpenCost UI/API request-based efficiency. Consider rightsizing container requests."
       "summary": "Namespace {{ $labels.namespace }} on {{ $labels.cluster }} is chronically under-utilizing its requests"
     "expr": |
-      avg_over_time(namespace:efficiency_total:ratio[7d]) < 0.20000000000000001
+      (
+        avg_over_time(namespace:efficiency_total:ratio[7d]) < 0.20000000000000001
+      )
+      and on(cluster, namespace)
+      (
+        (
+          avg_over_time(namespace:opencost_cpu_cost:sum[7d])
+          +
+          avg_over_time(namespace:opencost_ram_cost:sum[7d])
+        ) * 730 > 100
+      )
     "for": "1h"
     "labels":
       "severity": "info"

--- a/prometheus_alerts.yaml
+++ b/prometheus_alerts.yaml
@@ -146,15 +146,10 @@
   - "alert": "OpenCostLowEfficiencyNamespace"
     "annotations":
       "dashboard_url": "https://grafana.com/d/opencost-mixin-namespace-jkwq/opencost-namespace"
-      "description": "Total CPU+RAM cost-weighted efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has averaged {{ $value | humanizePercentage }} over the last 7 days while projected monthly cost exceeds $500. Consider rightsizing container requests. Formula mirrors OpenCost allocation.go (CPUEfficiency, RAMEfficiency, TotalEfficiency) — spec at https://www.opencost.io/docs/specification#efficiency."
+      "description": "Total CPU+RAM cost-weighted efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has averaged {{ $value | humanizePercentage }} over the last 7 days. Consider rightsizing container requests. Formula mirrors OpenCost allocation.go (CPUEfficiency, RAMEfficiency, TotalEfficiency) — spec at https://www.opencost.io/docs/specification#efficiency."
       "summary": "Namespace {{ $labels.namespace }} on {{ $labels.cluster }} is chronically under-utilizing its requests"
     "expr": |
       avg_over_time(namespace:efficiency_total:ratio[7d]) < 0.20000000000000001
-      and
-      (
-        avg_over_time(namespace:opencost_cpu_cost:sum[7d])
-        + avg_over_time(namespace:opencost_ram_cost:sum[7d])
-      ) * 730 > 500
     "for": "1h"
     "labels":
       "severity": "info"

--- a/prometheus_alerts.yaml
+++ b/prometheus_alerts.yaml
@@ -146,7 +146,7 @@
   - "alert": "OpenCostLowEfficiencyNamespace"
     "annotations":
       "dashboard_url": "https://grafana.com/d/opencost-mixin-namespace-jkwq/opencost-namespace"
-      "description": "Total CPU+RAM cost-weighted efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has averaged {{ $value | humanizePercentage }} over the last 7 days. Consider rightsizing container requests. Formula mirrors OpenCost allocation.go (CPUEfficiency, RAMEfficiency, TotalEfficiency) — spec at https://www.opencost.io/docs/specification#efficiency."
+      "description": "Total CPU+RAM cost-weighted allocation efficiency for namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has averaged {{ $value | humanizePercentage }} over the last 7 days. This is usage divided by OpenCost-exported allocation, not exact OpenCost UI/API request-based efficiency. Consider rightsizing container requests."
       "summary": "Namespace {{ $labels.namespace }} on {{ $labels.cluster }} is chronically under-utilizing its requests"
     "expr": |
       avg_over_time(namespace:efficiency_total:ratio[7d]) < 0.20000000000000001

--- a/prometheus_rules.yaml
+++ b/prometheus_rules.yaml
@@ -4,7 +4,7 @@
   "rules":
   - "expr": |
       sum by (cluster, namespace) (
-        rate(container_cpu_usage_seconds_total{container!="",image!=""}[5m])
+        rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", image!=""}[5m])
       )
       /
       sum by (cluster, namespace) (
@@ -13,7 +13,7 @@
     "record": "namespace:efficiency_cpu:ratio"
   - "expr": |
       sum by (cluster, namespace) (
-        container_memory_working_set_bytes{container!="",image!=""}
+        container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", image!=""}
       )
       /
       sum by (cluster, namespace) (
@@ -37,7 +37,7 @@
     "record": "namespace:efficiency_total:ratio"
   - "expr": |
       sum by (cluster, namespace, workload_type, workload) (
-        rate(container_cpu_usage_seconds_total{container!="",image!=""}[5m])
+        rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", image!=""}[5m])
         * on(cluster, namespace, pod) group_left(workload_type, workload)
         max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
       )
@@ -50,7 +50,7 @@
     "record": "workload:efficiency_cpu:ratio"
   - "expr": |
       sum by (cluster, namespace, workload_type, workload) (
-        container_memory_working_set_bytes{container!="",image!=""}
+        container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", image!=""}
         * on(cluster, namespace, pod) group_left(workload_type, workload)
         max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
       )

--- a/prometheus_rules.yaml
+++ b/prometheus_rules.yaml
@@ -1,5 +1,78 @@
 "groups":
 - "interval": "5m"
+  "name": "opencost.rules.efficiency"
+  "rules":
+  - "expr": |
+      sum by (cluster, namespace) (
+        rate(container_cpu_usage_seconds_total{container!="",image!=""}[5m])
+      )
+      /
+      sum by (cluster, namespace) (
+        container_cpu_allocation{job="opencost"}
+      )
+    "record": "namespace:efficiency_cpu:ratio"
+  - "expr": |
+      sum by (cluster, namespace) (
+        container_memory_working_set_bytes{container!="",image!=""}
+      )
+      /
+      sum by (cluster, namespace) (
+        container_memory_allocation_bytes{job="opencost"}
+      )
+    "record": "namespace:efficiency_ram:ratio"
+  - "expr": "sum by (cluster, namespace) (workload:opencost_cpu_cost:sum)"
+    "record": "namespace:opencost_cpu_cost:sum"
+  - "expr": "sum by (cluster, namespace) (workload:opencost_ram_cost:sum)"
+    "record": "namespace:opencost_ram_cost:sum"
+  - "expr": |
+      (
+        namespace:opencost_cpu_cost:sum * namespace:efficiency_cpu:ratio
+        +
+        namespace:opencost_ram_cost:sum * namespace:efficiency_ram:ratio
+      )
+      /
+      (
+        namespace:opencost_cpu_cost:sum + namespace:opencost_ram_cost:sum
+      )
+    "record": "namespace:efficiency_total:ratio"
+  - "expr": |
+      sum by (cluster, namespace, workload_type, workload) (
+        rate(container_cpu_usage_seconds_total{container!="",image!=""}[5m])
+        * on(cluster, namespace, pod) group_left(workload_type, workload)
+        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
+      )
+      /
+      sum by (cluster, namespace, workload_type, workload) (
+        container_cpu_allocation{job="opencost"}
+        * on(cluster, namespace, pod) group_left(workload_type, workload)
+        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
+      )
+    "record": "workload:efficiency_cpu:ratio"
+  - "expr": |
+      sum by (cluster, namespace, workload_type, workload) (
+        container_memory_working_set_bytes{container!="",image!=""}
+        * on(cluster, namespace, pod) group_left(workload_type, workload)
+        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
+      )
+      /
+      sum by (cluster, namespace, workload_type, workload) (
+        container_memory_allocation_bytes{job="opencost"}
+        * on(cluster, namespace, pod) group_left(workload_type, workload)
+        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
+      )
+    "record": "workload:efficiency_ram:ratio"
+  - "expr": |
+      (
+        workload:opencost_cpu_cost:sum * workload:efficiency_cpu:ratio
+        +
+        workload:opencost_ram_cost:sum * workload:efficiency_ram:ratio
+      )
+      /
+      (
+        workload:opencost_cpu_cost:sum + workload:opencost_ram_cost:sum
+      )
+    "record": "workload:efficiency_total:ratio"
+- "interval": "5m"
   "name": "opencost.rules.workload"
   "rules":
   - "expr": |

--- a/prometheus_rules.yaml
+++ b/prometheus_rules.yaml
@@ -4,7 +4,7 @@
   "rules":
   - "expr": |
       sum by (cluster, namespace) (
-        rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", image!=""}[5m])
+        rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}[5m])
       )
       /
       sum by (cluster, namespace) (
@@ -13,7 +13,7 @@
     "record": "namespace:efficiency_cpu:ratio"
   - "expr": |
       sum by (cluster, namespace) (
-        container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", image!=""}
+        container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}
       )
       /
       sum by (cluster, namespace) (
@@ -37,7 +37,7 @@
     "record": "namespace:efficiency_total:ratio"
   - "expr": |
       sum by (cluster, namespace, workload_type, workload) (
-        rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", image!=""}[5m])
+        rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}[5m])
         * on(cluster, namespace, pod) group_left(workload_type, workload)
         max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
       )
@@ -50,7 +50,7 @@
     "record": "workload:efficiency_cpu:ratio"
   - "expr": |
       sum by (cluster, namespace, workload_type, workload) (
-        container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", image!=""}
+        container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}
         * on(cluster, namespace, pod) group_left(workload_type, workload)
         max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
       )

--- a/prometheus_rules.yaml
+++ b/prometheus_rules.yaml
@@ -25,49 +25,127 @@
   - "expr": "sum by (cluster, namespace) (workload:opencost_ram_cost:sum)"
     "record": "namespace:opencost_ram_cost:sum"
   - "expr": |
+      sum by (cluster, namespace, workload_type, workload) (
+        (
+        max by (cluster, namespace, pod, workload_type, workload) (
+        namespace_workload_pod:kube_pod_owner:relabel
+      )
+      
+        /
+        on(cluster, namespace, pod) group_left()
+        count by (cluster, namespace, pod) (
+          max by (cluster, namespace, pod, workload_type, workload) (
+        namespace_workload_pod:kube_pod_owner:relabel
+      )
+      
+        )
+      )
+      
+        * on(cluster, namespace, pod) group_left()
+        sum by (cluster, namespace, pod) (
+          rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}[5m])
+        )
+      )
+      
+      /
+      sum by (cluster, namespace, workload_type, workload) (
+        (
+        max by (cluster, namespace, pod, workload_type, workload) (
+        namespace_workload_pod:kube_pod_owner:relabel
+      )
+      
+        /
+        on(cluster, namespace, pod) group_left()
+        count by (cluster, namespace, pod) (
+          max by (cluster, namespace, pod, workload_type, workload) (
+        namespace_workload_pod:kube_pod_owner:relabel
+      )
+      
+        )
+      )
+      
+        * on(cluster, namespace, pod) group_left()
+        sum by (cluster, namespace, pod) (
+          container_cpu_allocation{job="opencost"}
+        )
+      )
+      
+    "record": "workload:efficiency_cpu:ratio"
+  - "expr": |
+      sum by (cluster, namespace, workload_type, workload) (
+        (
+        max by (cluster, namespace, pod, workload_type, workload) (
+        namespace_workload_pod:kube_pod_owner:relabel
+      )
+      
+        /
+        on(cluster, namespace, pod) group_left()
+        count by (cluster, namespace, pod) (
+          max by (cluster, namespace, pod, workload_type, workload) (
+        namespace_workload_pod:kube_pod_owner:relabel
+      )
+      
+        )
+      )
+      
+        * on(cluster, namespace, pod) group_left()
+        sum by (cluster, namespace, pod) (
+          container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}
+        )
+      )
+      
+      /
+      sum by (cluster, namespace, workload_type, workload) (
+        (
+        max by (cluster, namespace, pod, workload_type, workload) (
+        namespace_workload_pod:kube_pod_owner:relabel
+      )
+      
+        /
+        on(cluster, namespace, pod) group_left()
+        count by (cluster, namespace, pod) (
+          max by (cluster, namespace, pod, workload_type, workload) (
+        namespace_workload_pod:kube_pod_owner:relabel
+      )
+      
+        )
+      )
+      
+        * on(cluster, namespace, pod) group_left()
+        sum by (cluster, namespace, pod) (
+          container_memory_allocation_bytes{job="opencost"}
+        )
+      )
+      
+    "record": "workload:efficiency_ram:ratio"
+  - "expr": |
       (
-        namespace:opencost_cpu_cost:sum * namespace:efficiency_cpu:ratio
+        namespace:opencost_cpu_cost:sum
+        * on(cluster, namespace)
+        namespace:efficiency_cpu:ratio
         +
-        namespace:opencost_ram_cost:sum * namespace:efficiency_ram:ratio
+        namespace:opencost_ram_cost:sum
+        * on(cluster, namespace)
+        namespace:efficiency_ram:ratio
       )
       /
+      on(cluster, namespace)
       (
         namespace:opencost_cpu_cost:sum + namespace:opencost_ram_cost:sum
       )
     "record": "namespace:efficiency_total:ratio"
   - "expr": |
-      sum by (cluster, namespace, workload_type, workload) (
-        rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}[5m])
-        * on(cluster, namespace, pod) group_left(workload_type, workload)
-        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
-      )
-      /
-      sum by (cluster, namespace, workload_type, workload) (
-        container_cpu_allocation{job="opencost"}
-        * on(cluster, namespace, pod) group_left(workload_type, workload)
-        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
-      )
-    "record": "workload:efficiency_cpu:ratio"
-  - "expr": |
-      sum by (cluster, namespace, workload_type, workload) (
-        container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}
-        * on(cluster, namespace, pod) group_left(workload_type, workload)
-        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
-      )
-      /
-      sum by (cluster, namespace, workload_type, workload) (
-        container_memory_allocation_bytes{job="opencost"}
-        * on(cluster, namespace, pod) group_left(workload_type, workload)
-        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
-      )
-    "record": "workload:efficiency_ram:ratio"
-  - "expr": |
       (
-        workload:opencost_cpu_cost:sum * workload:efficiency_cpu:ratio
+        workload:opencost_cpu_cost:sum
+        * on(cluster, namespace, workload_type, workload)
+        workload:efficiency_cpu:ratio
         +
-        workload:opencost_ram_cost:sum * workload:efficiency_ram:ratio
+        workload:opencost_ram_cost:sum
+        * on(cluster, namespace, workload_type, workload)
+        workload:efficiency_ram:ratio
       )
       /
+      on(cluster, namespace, workload_type, workload)
       (
         workload:opencost_cpu_cost:sum + workload:opencost_ram_cost:sum
       )

--- a/prometheus_rules.yaml
+++ b/prometheus_rules.yaml
@@ -26,95 +26,39 @@
     "record": "namespace:opencost_ram_cost:sum"
   - "expr": |
       sum by (cluster, namespace, workload_type, workload) (
-        (
-        max by (cluster, namespace, pod, workload_type, workload) (
-        namespace_workload_pod:kube_pod_owner:relabel
-      )
-      
-        /
-        on(cluster, namespace, pod) group_left()
-        count by (cluster, namespace, pod) (
-          max by (cluster, namespace, pod, workload_type, workload) (
-        namespace_workload_pod:kube_pod_owner:relabel
-      )
-      
-        )
-      )
-      
-        * on(cluster, namespace, pod) group_left()
         sum by (cluster, namespace, pod) (
           rate(container_cpu_usage_seconds_total{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}[5m])
         )
+        * on(cluster, namespace, pod) group_left(workload_type, workload)
+        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
       )
       
       /
       sum by (cluster, namespace, workload_type, workload) (
-        (
-        max by (cluster, namespace, pod, workload_type, workload) (
-        namespace_workload_pod:kube_pod_owner:relabel
-      )
-      
-        /
-        on(cluster, namespace, pod) group_left()
-        count by (cluster, namespace, pod) (
-          max by (cluster, namespace, pod, workload_type, workload) (
-        namespace_workload_pod:kube_pod_owner:relabel
-      )
-      
-        )
-      )
-      
-        * on(cluster, namespace, pod) group_left()
         sum by (cluster, namespace, pod) (
           container_cpu_allocation{job="opencost"}
         )
+        * on(cluster, namespace, pod) group_left(workload_type, workload)
+        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
       )
       
     "record": "workload:efficiency_cpu:ratio"
   - "expr": |
       sum by (cluster, namespace, workload_type, workload) (
-        (
-        max by (cluster, namespace, pod, workload_type, workload) (
-        namespace_workload_pod:kube_pod_owner:relabel
-      )
-      
-        /
-        on(cluster, namespace, pod) group_left()
-        count by (cluster, namespace, pod) (
-          max by (cluster, namespace, pod, workload_type, workload) (
-        namespace_workload_pod:kube_pod_owner:relabel
-      )
-      
-        )
-      )
-      
-        * on(cluster, namespace, pod) group_left()
         sum by (cluster, namespace, pod) (
           container_memory_working_set_bytes{job="kube-system/cadvisor", container!="", container_name!="POD", container!="POD"}
         )
+        * on(cluster, namespace, pod) group_left(workload_type, workload)
+        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
       )
       
       /
       sum by (cluster, namespace, workload_type, workload) (
-        (
-        max by (cluster, namespace, pod, workload_type, workload) (
-        namespace_workload_pod:kube_pod_owner:relabel
-      )
-      
-        /
-        on(cluster, namespace, pod) group_left()
-        count by (cluster, namespace, pod) (
-          max by (cluster, namespace, pod, workload_type, workload) (
-        namespace_workload_pod:kube_pod_owner:relabel
-      )
-      
-        )
-      )
-      
-        * on(cluster, namespace, pod) group_left()
         sum by (cluster, namespace, pod) (
           container_memory_allocation_bytes{job="opencost"}
         )
+        * on(cluster, namespace, pod) group_left(workload_type, workload)
+        max by (cluster, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
       )
       
     "record": "workload:efficiency_ram:ratio"

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -15,7 +15,7 @@
             record: 'namespace:efficiency_cpu:ratio',
             expr: |||
               sum by (%(clusterLabel)s, namespace) (
-                rate(container_cpu_usage_seconds_total{container!="",image!=""}[5m])
+                rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, container!="", image!=""}[5m])
               )
               /
               sum by (%(clusterLabel)s, namespace) (
@@ -27,7 +27,7 @@
             record: 'namespace:efficiency_ram:ratio',
             expr: |||
               sum by (%(clusterLabel)s, namespace) (
-                container_memory_working_set_bytes{container!="",image!=""}
+                container_memory_working_set_bytes{%(cadvisorSelector)s, container!="", image!=""}
               )
               /
               sum by (%(clusterLabel)s, namespace) (
@@ -61,7 +61,7 @@
             record: 'workload:efficiency_cpu:ratio',
             expr: |||
               sum by (%(clusterLabel)s, namespace, workload_type, workload) (
-                rate(container_cpu_usage_seconds_total{container!="",image!=""}[5m])
+                rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, container!="", image!=""}[5m])
                 * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
                 max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
               )
@@ -77,7 +77,7 @@
             record: 'workload:efficiency_ram:ratio',
             expr: |||
               sum by (%(clusterLabel)s, namespace, workload_type, workload) (
-                container_memory_working_set_bytes{container!="",image!=""}
+                container_memory_working_set_bytes{%(cadvisorSelector)s, container!="", image!=""}
                 * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
                 max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
               )

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -1,6 +1,110 @@
+// Efficiency recording rules mirror OpenCost's native CPUEfficiency / RAMEfficiency /
+// TotalEfficiency calculation (see core/pkg/opencost/allocation.go — usage / allocation,
+// cost-weighted combination — https://www.opencost.io/docs/specification#efficiency).
+// The allocation series (container_cpu_allocation, container_memory_allocation_bytes)
+// are OpenCost's internal max(request, usage) × pod-uptime values, so using them
+// as the denominator keeps dashboard numbers within ~2% of the OpenCost UI.
 {
   prometheusRules+:: {
     groups+: [
+      {
+        name: 'opencost.rules.efficiency',
+        interval: '5m',
+        rules: [
+          {
+            record: 'namespace:efficiency_cpu:ratio',
+            expr: |||
+              sum by (%(clusterLabel)s, namespace) (
+                rate(container_cpu_usage_seconds_total{container!="",image!=""}[5m])
+              )
+              /
+              sum by (%(clusterLabel)s, namespace) (
+                container_cpu_allocation{%(openCostSelector)s}
+              )
+            ||| % $._config,
+          },
+          {
+            record: 'namespace:efficiency_ram:ratio',
+            expr: |||
+              sum by (%(clusterLabel)s, namespace) (
+                container_memory_working_set_bytes{container!="",image!=""}
+              )
+              /
+              sum by (%(clusterLabel)s, namespace) (
+                container_memory_allocation_bytes{%(openCostSelector)s}
+              )
+            ||| % $._config,
+          },
+          {
+            record: 'namespace:opencost_cpu_cost:sum',
+            expr: 'sum by (%(clusterLabel)s, namespace) (workload:opencost_cpu_cost:sum)' % $._config,
+          },
+          {
+            record: 'namespace:opencost_ram_cost:sum',
+            expr: 'sum by (%(clusterLabel)s, namespace) (workload:opencost_ram_cost:sum)' % $._config,
+          },
+          {
+            record: 'namespace:efficiency_total:ratio',
+            expr: |||
+              (
+                namespace:opencost_cpu_cost:sum * namespace:efficiency_cpu:ratio
+                +
+                namespace:opencost_ram_cost:sum * namespace:efficiency_ram:ratio
+              )
+              /
+              (
+                namespace:opencost_cpu_cost:sum + namespace:opencost_ram_cost:sum
+              )
+            |||,
+          },
+          {
+            record: 'workload:efficiency_cpu:ratio',
+            expr: |||
+              sum by (%(clusterLabel)s, namespace, workload_type, workload) (
+                rate(container_cpu_usage_seconds_total{container!="",image!=""}[5m])
+                * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
+                max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
+              )
+              /
+              sum by (%(clusterLabel)s, namespace, workload_type, workload) (
+                container_cpu_allocation{%(openCostSelector)s}
+                * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
+                max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
+              )
+            ||| % $._config,
+          },
+          {
+            record: 'workload:efficiency_ram:ratio',
+            expr: |||
+              sum by (%(clusterLabel)s, namespace, workload_type, workload) (
+                container_memory_working_set_bytes{container!="",image!=""}
+                * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
+                max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
+              )
+              /
+              sum by (%(clusterLabel)s, namespace, workload_type, workload) (
+                container_memory_allocation_bytes{%(openCostSelector)s}
+                * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
+                max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
+              )
+            ||| % $._config,
+          },
+          {
+            record: 'workload:efficiency_total:ratio',
+            expr: |||
+              (
+                workload:opencost_cpu_cost:sum * workload:efficiency_cpu:ratio
+                +
+                workload:opencost_ram_cost:sum * workload:efficiency_ram:ratio
+              )
+              /
+              (
+                workload:opencost_cpu_cost:sum + workload:opencost_ram_cost:sum
+              )
+            |||,
+          },
+        ],
+      },
       {
         name: 'opencost.rules.workload',
         interval: '5m',

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -1,18 +1,21 @@
-// Efficiency recording rules mirror OpenCost's native CPUEfficiency / RAMEfficiency /
-// TotalEfficiency calculation. The numerator metrics (rate of
-// container_cpu_usage_seconds_total, container_memory_working_set_bytes) and the
-// container_name!="POD"/container!="POD" filter are taken from the same Prometheus
-// queries OpenCost itself runs against cAdvisor:
+// Efficiency recording rules approximate OpenCost efficiency from exported
+// Prometheus metrics. OpenCost does not export CPUEfficiency / RAMEfficiency /
+// TotalEfficiency directly, so these rules use OpenCost allocation metrics as
+// denominators. The numerator metrics (rate of container_cpu_usage_seconds_total,
+// container_memory_working_set_bytes) and the container_name!="POD"/container!="POD"
+// filter are taken from the same Prometheus queries OpenCost itself runs against
+// cAdvisor:
 //   QueryCPUUsageAvg / QueryRAMUsageAvg in
 //   https://github.com/opencost/opencost/blob/develop/modules/prometheus-source/pkg/prom/metricsquerier.go
-// The Allocation efficiency methods that combine these into the UI numbers:
+// OpenCost's native API/UI efficiency methods use request-average denominators:
 //   CPUEfficiency / RAMEfficiency / TotalEfficiency in
 //   https://github.com/opencost/opencost/blob/develop/core/pkg/opencost/allocation.go
 // Spec: https://www.opencost.io/docs/specification#efficiency
 //
 // The allocation series (container_cpu_allocation, container_memory_allocation_bytes)
-// are OpenCost's internal max(request, usage) × pod-uptime values, so using them
-// as the denominator keeps dashboard numbers within ~2% of the OpenCost UI.
+// are OpenCost's own exported allocation model (roughly max(request, usage)), so
+// these rules report "usage / OpenCost allocation". This is allocation efficiency,
+// not byte-for-byte parity with the OpenCost UI/API's request-based efficiency.
 //
 // rate(...[5m]) window: the rule group fires every 5m, so a 5m rate produces one
 // fresh sample per evaluation; with kubelet scraping at 15–30s this gives

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -18,6 +18,61 @@
 // fresh sample per evaluation; with kubelet scraping at 15–30s this gives
 // ~10–20 samples per rate (well above Prometheus's "≥4 samples" rule of thumb).
 {
+  local clusterNamespace = '%(clusterLabel)s, namespace' % $._config,
+  local clusterNamespacePod = '%(clusterLabel)s, namespace, pod' % $._config,
+  local workloadLabels = '%(clusterLabel)s, namespace, workload_type, workload' % $._config,
+  local cadvisorContainerSelector = '%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"' % $._config,
+  local workloadOwner = |||
+    max by (%(clusterNamespacePod)s, workload_type, workload) (
+      namespace_workload_pod:kube_pod_owner:relabel
+    )
+  ||| % { clusterNamespacePod: clusterNamespacePod },
+  local workloadOwnerFraction = |||
+    (
+      %(workloadOwner)s
+      /
+      on(%(clusterNamespacePod)s) group_left()
+      count by (%(clusterNamespacePod)s) (
+        %(workloadOwner)s
+      )
+    )
+  ||| % {
+    clusterNamespacePod: clusterNamespacePod,
+    workloadOwner: workloadOwner,
+  },
+  local workloadEfficiency(metricExpr) = |||
+    sum by (%(workloadLabels)s) (
+      %(workloadOwnerFraction)s
+      * on(%(clusterNamespacePod)s) group_left()
+      sum by (%(clusterNamespacePod)s) (
+        %(metricExpr)s
+      )
+    )
+  ||| % {
+    clusterNamespacePod: clusterNamespacePod,
+    metricExpr: metricExpr,
+    workloadLabels: workloadLabels,
+    workloadOwnerFraction: workloadOwnerFraction,
+  },
+  local costWeightedEfficiencyTotal(scope, labels) = |||
+    (
+      %(scope)s:opencost_cpu_cost:sum
+      * on(%(labels)s)
+      %(scope)s:efficiency_cpu:ratio
+      +
+      %(scope)s:opencost_ram_cost:sum
+      * on(%(labels)s)
+      %(scope)s:efficiency_ram:ratio
+    )
+    /
+    on(%(labels)s)
+    (
+      %(scope)s:opencost_cpu_cost:sum + %(scope)s:opencost_ram_cost:sum
+    )
+  ||| % {
+    labels: labels,
+    scope: scope,
+  },
   prometheusRules+:: {
     groups+: [
       {
@@ -27,94 +82,70 @@
           {
             record: 'namespace:efficiency_cpu:ratio',
             expr: |||
-              sum by (%(clusterLabel)s, namespace) (
-                rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"}[5m])
+              sum by (%(clusterNamespace)s) (
+                rate(container_cpu_usage_seconds_total{%(cadvisorContainerSelector)s}[5m])
               )
               /
-              sum by (%(clusterLabel)s, namespace) (
+              sum by (%(clusterNamespace)s) (
                 container_cpu_allocation{%(openCostSelector)s}
               )
-            ||| % $._config,
+            ||| % ($._config {
+                     cadvisorContainerSelector: cadvisorContainerSelector,
+                     clusterNamespace: clusterNamespace,
+                   }),
           },
           {
             record: 'namespace:efficiency_ram:ratio',
             expr: |||
-              sum by (%(clusterLabel)s, namespace) (
-                container_memory_working_set_bytes{%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"}
+              sum by (%(clusterNamespace)s) (
+                container_memory_working_set_bytes{%(cadvisorContainerSelector)s}
               )
               /
-              sum by (%(clusterLabel)s, namespace) (
+              sum by (%(clusterNamespace)s) (
                 container_memory_allocation_bytes{%(openCostSelector)s}
               )
-            ||| % $._config,
+            ||| % ($._config {
+                     cadvisorContainerSelector: cadvisorContainerSelector,
+                     clusterNamespace: clusterNamespace,
+                   }),
           },
           {
             record: 'namespace:opencost_cpu_cost:sum',
-            expr: 'sum by (%(clusterLabel)s, namespace) (workload:opencost_cpu_cost:sum)' % $._config,
+            expr: 'sum by (%s) (workload:opencost_cpu_cost:sum)' % clusterNamespace,
           },
           {
             record: 'namespace:opencost_ram_cost:sum',
-            expr: 'sum by (%(clusterLabel)s, namespace) (workload:opencost_ram_cost:sum)' % $._config,
-          },
-          {
-            record: 'namespace:efficiency_total:ratio',
-            expr: |||
-              (
-                namespace:opencost_cpu_cost:sum * namespace:efficiency_cpu:ratio
-                +
-                namespace:opencost_ram_cost:sum * namespace:efficiency_ram:ratio
-              )
-              /
-              (
-                namespace:opencost_cpu_cost:sum + namespace:opencost_ram_cost:sum
-              )
-            |||,
+            expr: 'sum by (%s) (workload:opencost_ram_cost:sum)' % clusterNamespace,
           },
           {
             record: 'workload:efficiency_cpu:ratio',
             expr: |||
-              sum by (%(clusterLabel)s, namespace, workload_type, workload) (
-                rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"}[5m])
-                * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
-                max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
-              )
+              %(workloadCpuUsage)s
               /
-              sum by (%(clusterLabel)s, namespace, workload_type, workload) (
-                container_cpu_allocation{%(openCostSelector)s}
-                * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
-                max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
-              )
-            ||| % $._config,
+              %(workloadCpuAllocation)s
+            ||| % {
+              workloadCpuAllocation: workloadEfficiency('container_cpu_allocation{%(openCostSelector)s}' % $._config),
+              workloadCpuUsage: workloadEfficiency('rate(container_cpu_usage_seconds_total{%(cadvisorContainerSelector)s}[5m])' % { cadvisorContainerSelector: cadvisorContainerSelector }),
+            },
           },
           {
             record: 'workload:efficiency_ram:ratio',
             expr: |||
-              sum by (%(clusterLabel)s, namespace, workload_type, workload) (
-                container_memory_working_set_bytes{%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"}
-                * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
-                max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
-              )
+              %(workloadRamUsage)s
               /
-              sum by (%(clusterLabel)s, namespace, workload_type, workload) (
-                container_memory_allocation_bytes{%(openCostSelector)s}
-                * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
-                max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
-              )
-            ||| % $._config,
+              %(workloadRamAllocation)s
+            ||| % {
+              workloadRamAllocation: workloadEfficiency('container_memory_allocation_bytes{%(openCostSelector)s}' % $._config),
+              workloadRamUsage: workloadEfficiency('container_memory_working_set_bytes{%(cadvisorContainerSelector)s}' % { cadvisorContainerSelector: cadvisorContainerSelector }),
+            },
+          },
+          {
+            record: 'namespace:efficiency_total:ratio',
+            expr: costWeightedEfficiencyTotal('namespace', clusterNamespace),
           },
           {
             record: 'workload:efficiency_total:ratio',
-            expr: |||
-              (
-                workload:opencost_cpu_cost:sum * workload:efficiency_cpu:ratio
-                +
-                workload:opencost_ram_cost:sum * workload:efficiency_ram:ratio
-              )
-              /
-              (
-                workload:opencost_cpu_cost:sum + workload:opencost_ram_cost:sum
-              )
-            |||,
+            expr: costWeightedEfficiencyTotal('workload', workloadLabels),
           },
         ],
       },

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -1,9 +1,22 @@
 // Efficiency recording rules mirror OpenCost's native CPUEfficiency / RAMEfficiency /
-// TotalEfficiency calculation (see core/pkg/opencost/allocation.go — usage / allocation,
-// cost-weighted combination — https://www.opencost.io/docs/specification#efficiency).
+// TotalEfficiency calculation. The numerator metrics (rate of
+// container_cpu_usage_seconds_total, container_memory_working_set_bytes) and the
+// container_name!="POD"/container!="POD" filter are taken from the same Prometheus
+// queries OpenCost itself runs against cAdvisor:
+//   QueryCPUUsageAvg / QueryRAMUsageAvg in
+//   https://github.com/opencost/opencost/blob/develop/modules/prometheus-source/pkg/prom/metricsquerier.go
+// The Allocation efficiency methods that combine these into the UI numbers:
+//   CPUEfficiency / RAMEfficiency / TotalEfficiency in
+//   https://github.com/opencost/opencost/blob/develop/core/pkg/opencost/allocation.go
+// Spec: https://www.opencost.io/docs/specification#efficiency
+//
 // The allocation series (container_cpu_allocation, container_memory_allocation_bytes)
 // are OpenCost's internal max(request, usage) × pod-uptime values, so using them
 // as the denominator keeps dashboard numbers within ~2% of the OpenCost UI.
+//
+// rate(...[5m]) window: the rule group fires every 5m, so a 5m rate produces one
+// fresh sample per evaluation; with kubelet scraping at 15–30s this gives
+// ~10–20 samples per rate (well above Prometheus's "≥4 samples" rule of thumb).
 {
   prometheusRules+:: {
     groups+: [
@@ -15,7 +28,7 @@
             record: 'namespace:efficiency_cpu:ratio',
             expr: |||
               sum by (%(clusterLabel)s, namespace) (
-                rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, container!="", image!=""}[5m])
+                rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"}[5m])
               )
               /
               sum by (%(clusterLabel)s, namespace) (
@@ -27,7 +40,7 @@
             record: 'namespace:efficiency_ram:ratio',
             expr: |||
               sum by (%(clusterLabel)s, namespace) (
-                container_memory_working_set_bytes{%(cadvisorSelector)s, container!="", image!=""}
+                container_memory_working_set_bytes{%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"}
               )
               /
               sum by (%(clusterLabel)s, namespace) (
@@ -61,7 +74,7 @@
             record: 'workload:efficiency_cpu:ratio',
             expr: |||
               sum by (%(clusterLabel)s, namespace, workload_type, workload) (
-                rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, container!="", image!=""}[5m])
+                rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"}[5m])
                 * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
                 max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
               )
@@ -77,7 +90,7 @@
             record: 'workload:efficiency_ram:ratio',
             expr: |||
               sum by (%(clusterLabel)s, namespace, workload_type, workload) (
-                container_memory_working_set_bytes{%(cadvisorSelector)s, container!="", image!=""}
+                container_memory_working_set_bytes{%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"}
                 * on(%(clusterLabel)s, namespace, pod) group_left(workload_type, workload)
                 max by (%(clusterLabel)s, namespace, pod, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)
               )

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -22,37 +22,20 @@
   local clusterNamespacePod = '%(clusterLabel)s, namespace, pod' % $._config,
   local workloadLabels = '%(clusterLabel)s, namespace, workload_type, workload' % $._config,
   local cadvisorContainerSelector = '%(cadvisorSelector)s, container!="", container_name!="POD", container!="POD"' % $._config,
-  local workloadOwner = |||
-    max by (%(clusterNamespacePod)s, workload_type, workload) (
-      namespace_workload_pod:kube_pod_owner:relabel
-    )
-  ||| % { clusterNamespacePod: clusterNamespacePod },
-  local workloadOwnerFraction = |||
-    (
-      %(workloadOwner)s
-      /
-      on(%(clusterNamespacePod)s) group_left()
-      count by (%(clusterNamespacePod)s) (
-        %(workloadOwner)s
-      )
-    )
-  ||| % {
-    clusterNamespacePod: clusterNamespacePod,
-    workloadOwner: workloadOwner,
-  },
+  local workloadOwner = 'max by (%s, workload_type, workload) (namespace_workload_pod:kube_pod_owner:relabel)' % clusterNamespacePod,
   local workloadEfficiency(metricExpr) = |||
     sum by (%(workloadLabels)s) (
-      %(workloadOwnerFraction)s
-      * on(%(clusterNamespacePod)s) group_left()
       sum by (%(clusterNamespacePod)s) (
         %(metricExpr)s
       )
+      * on(%(clusterNamespacePod)s) group_left(workload_type, workload)
+      %(workloadOwner)s
     )
   ||| % {
     clusterNamespacePod: clusterNamespacePod,
     metricExpr: metricExpr,
     workloadLabels: workloadLabels,
-    workloadOwnerFraction: workloadOwnerFraction,
+    workloadOwner: workloadOwner,
   },
   local costWeightedEfficiencyTotal(scope, labels) = |||
     (


### PR DESCRIPTION
Adds allocation-efficiency visibility to the OpenCost dashboards using metrics already exported by OpenCost.

  OpenCost does not currently export `CPUEfficiency`, `RAMEfficiency`, or `TotalEfficiency` as Prometheus metrics. This PR adds recording rules that approximate efficiency from exported Prometheus metrics by comparing cAdvisor usage with OpenCost allocation metrics:

  - CPU allocation efficiency: `rate(container_cpu_usage_seconds_total[5m]) / container_cpu_allocation`
  - RAM allocation efficiency: `container_memory_working_set_bytes / container_memory_allocation_bytes`
  - Total allocation efficiency: CPU/RAM efficiency weighted by CPU/RAM cost

  This intentionally uses OpenCost allocation metrics as denominators so the dashboards stay aligned with OpenCost's allocation and cost model. It is not exact OpenCost UI/API parity, because native OpenCost efficiency uses request-average denominators.

  Includes:

  - recording rules under `opencost.rules.efficiency` for namespace and workload CPU/RAM/total allocation efficiency
  - namespace CPU/RAM cost aggregation rules used for total-efficiency cost weighting
  - percentage-only efficiency panels on the overview, namespace, and workload dashboards
  - configurable `OpenCostLowEfficiencyNamespace` alert under `alerts.efficiency`
  - configurable `cadvisorSelector` for environments where cAdvisor is scraped under a non-default job label