### PR TITLE
feat: make cluster multi-select and include-all configurable

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -21,6 +21,8 @@ local annotation = g.dashboard.annotation;
 
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
     showMultiCluster: false,
+    multiClusterAllowsMultipleSelection: false,
+    multiClusterIncludeAllValue: false,
     clusterLabel: 'cluster',
     namespaceLabel: 'namespace',
     podLabel: 'pod',

--- a/dashboards/opencost-overview.libsonnet
+++ b/dashboards/opencost-overview.libsonnet
@@ -587,7 +587,17 @@ local tbOverride = tbStandardOptions.override;
                   },
                 }
               ),
-            ]
+            ],
+            overrides=(
+              if std.all([$._config.showMultiCluster, !$._config.multiClusterAllowsMultipleSelection])
+              then
+                [
+                  tbOverride.byName.new('cluster') +
+                  tbOverride.byName.withProperty('custom.hideFrom.viz', true),
+                ]
+              else
+                []
+            )
           ),
 
         pvTable:

--- a/dashboards/util.libsonnet
+++ b/dashboards/util.libsonnet
@@ -75,7 +75,10 @@ local query = variable.query;
       query.withSort() +
       (
         if config.showMultiCluster
-        then query.generalOptions.showOnDashboard.withLabelAndValue()
+        then
+          query.generalOptions.showOnDashboard.withLabelAndValue() +
+          query.selectionOptions.withMulti(value=config.multiClusterAllowsMultipleSelection) +
+          query.selectionOptions.withIncludeAll(value=config.multiClusterIncludeAllValue)
         else query.generalOptions.showOnDashboard.withNothing()
       ),
 


### PR DESCRIPTION
Add `multiClusterAllowsMultipleSelection` and `multiClusterIncludeAllValue`
config options (both default `false`) mirroring the same change made in
adinhodovic/kubernetes-events-mixin#10.

- `config.libsonnet`: expose the two new keys alongside `showMultiCluster`
- `dashboards/util.libsonnet`: cluster variable now applies `withMulti` and
  `withIncludeAll` conditionally (only when `showMultiCluster` is true),
  driven by the new config values rather than hardcoded `true`
- `dashboards/opencost-overview.libsonnet`: hide the `cluster` column from
  the Nodes Monthly Cost table when `showMultiCluster` is enabled but
  multiple selection is disabled, since the value is always identical

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
